### PR TITLE
Fix order for `export { x as y }`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>bandolier</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2</version>
     <packaging>jar</packaging>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity</groupId>
     <artifactId>bandolier</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
 

--- a/src/main/java/com/shapesecurity/bandolier/ImportExportTransformer.java
+++ b/src/main/java/com/shapesecurity/bandolier/ImportExportTransformer.java
@@ -243,7 +243,7 @@ public class ImportExportTransformer {
 	// e.g., exports.x = x;
 	static private ExpressionStatement makeNamedExportStatement(ExportLocalSpecifier specifier) {
 		IdentifierExpression exportsIden = new IdentifierExpression("exports");
-		ComputedMemberAssignmentTarget staticMem = new ComputedMemberAssignmentTarget(exportsIden, new LiteralStringExpression(specifier.name.name));
+		ComputedMemberAssignmentTarget staticMem = new ComputedMemberAssignmentTarget(exportsIden, new LiteralStringExpression(specifier.exportedName.orJust(specifier.name.name)));
 
 		IdentifierExpression exportVar = makeExportVar(specifier);
 
@@ -267,7 +267,7 @@ public class ImportExportTransformer {
 	// e.g., exports.x = __resolver.x
 	static private ExpressionStatement makeNamedExportStatement(String resolver, ExportFromSpecifier specifier) {
 		IdentifierExpression exportsIden = new IdentifierExpression("exports");
-		ComputedMemberAssignmentTarget staticMem = new ComputedMemberAssignmentTarget(exportsIden, new LiteralStringExpression(specifier.name));
+		ComputedMemberAssignmentTarget staticMem = new ComputedMemberAssignmentTarget(exportsIden, new LiteralStringExpression(specifier.exportedName.orJust(specifier.name)));
 
 		ComputedMemberExpression exportVar = makeExportVar(resolver, specifier);
 
@@ -278,16 +278,14 @@ public class ImportExportTransformer {
 
 	// e.g., __resolver.x
 	static private ComputedMemberExpression makeExportVar(String resolver, ExportFromSpecifier specifier) {
-		String property = specifier.exportedName.isJust() ? specifier.exportedName.fromJust() : specifier.name;
+		String property = specifier.name;
 
 		return new ComputedMemberExpression(new IdentifierExpression(resolver), new LiteralStringExpression(property));
 	}
 
 	// e.g., x
 	static private IdentifierExpression makeExportVar(ExportLocalSpecifier specifier) {
-		return specifier.exportedName.isJust() ?
-			new IdentifierExpression(specifier.exportedName.fromJust()) :
-			new IdentifierExpression(specifier.name.name);
+		return new IdentifierExpression(specifier.name.name);
 	}
 
 	// e.g., require('lib');

--- a/src/test/java/com/shapesecurity/bandolier/ImportExportTransformerTest.java
+++ b/src/test/java/com/shapesecurity/bandolier/ImportExportTransformerTest.java
@@ -38,7 +38,10 @@ public class ImportExportTransformerTest extends TestCase {
 			"export * from 'm'");
 		testTransformer("var __resolver = require('m', module); exports['x'] = __resolver['x']",
 			"export {x} from 'm'");
+		testTransformer("var __resolver = require('m', module); exports['y'] = __resolver['x']",
+			"export {x as y} from 'm'");
 		testTransformer("exports['x'] = x", "export {x}");
+		testTransformer("exports['y'] = x", "export {x as y}");
 		testTransformer("var x = 0; exports['x'] = x", "export var x = 0");
 		testTransformer("function f(){} exports['f'] = f", "export function f(){}");
 		testTransformer("class C{} exports['C'] = C", "export class C{}");


### PR DESCRIPTION
Siiiiiiigh.

Contains version bump commits, so please **rebase**, not merge.