### PR TITLE
updated dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,24 +47,23 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.intellij</groupId>
+            <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>5.1</version>
-            <scope>compile</scope>
+            <version>16.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.shapesecurity.shift</groupId>
             <artifactId>es2016</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.shapesecurity</groupId>
             <artifactId>shape-functional-java</artifactId>
-            <version>2.1.0</version>
+            <version>2.5.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
updated to latest `shape-functional-java`.  The old version contained dependencies that were listed as vulnerable in the NVD CVE database.