### PR TITLE
Module piercing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/test/resources/test262"]
+	path = src/test/resources/test262
+	url = https://github.com/tc39/test262.git

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>shape-functional-java</artifactId>
             <version>2.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.16</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/src/main/java/com/shapesecurity/bandolier/es2017/Bundler.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/Bundler.java
@@ -42,8 +42,11 @@ import java.util.Map;
 
 public class Bundler {
 
+
+
 	/**
 	 * Bundles the module at the specified path using the default resolver and loaders
+	 * @param options options object
 	 * @param filePath path to the module
 	 * @return a bundled script
 	 * @throws ModuleLoaderException
@@ -53,9 +56,20 @@ public class Bundler {
 	}
 
 	/**
+	 * Bundles the module at the specified path using the default resolver and loaders, uses DEFAULT_OPTIONS.
+	 * @param filePath path to the module
+	 * @return a bundled script
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Script bundle(@NotNull Path filePath) throws ModuleLoaderException {
+		return bundle(BundlerOptions.DEFAULT_OPTIONS, filePath);
+	}
+
+	/**
 	 * Bundles the module specified by the given path and its dependencies and returns the resulting
 	 * Script.
 	 *
+	 * @param options options object
 	 * @param filePath is the path to the input entry point module.
 	 * @param resolver how to resolve the path
 	 * @param loader   how to load modules
@@ -71,9 +85,24 @@ public class Bundler {
 	}
 
 	/**
+	 * Bundles the module specified by the given path and its dependencies and returns the resulting
+	 * Script, uses DEFAULT_OPTIONS.
+	 *
+	 * @param filePath is the path to the input entry point module.
+	 * @param resolver how to resolve the path
+	 * @param loader   how to load modules
+	 * @return the resulting script
+	 * @throws ModuleLoaderException when the module fails to load
+	 */
+	public static @NotNull Script bundle(@NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundle(BundlerOptions.DEFAULT_OPTIONS, filePath, resolver, loader, bundler);
+	}
+
+	/**
 	 * Bundles the module provided as a string along with its dependencies and returns the resulting
 	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
 	 * of its input map, and the resolver and loader are well-behaved.
+	 * @param options options object
 	 * @param source the string of the module
 	 * @param filePath path to the module
 	 * @param resolver how to resolve paths
@@ -90,9 +119,25 @@ public class Bundler {
 	}
 
 	/**
+	 * Bundles the module provided as a string along with its dependencies and returns the resulting
+	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
+	 * of its input map, and the resolver and loader are well-behaved, uses DEFAULT_OPTIONS.
+	 * @param source the string of the module
+	 * @param filePath path to the module
+	 * @param resolver how to resolve paths
+	 * @param loader how to load modules
+	 * @return the resulting script
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Script bundleString(@NotNull String source, @NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundleString(BundlerOptions.DEFAULT_OPTIONS, source, filePath, resolver, loader, bundler);
+	}
+
+	/**
 	 * Bundles the module provided as a parsed Module along with its dependencies and returns the resulting
 	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
 	 * of its input map, and the resolver and loader are well-behaved.
+	 * @param options options object
 	 * @param mod the module
 	 * @param filePath path to the module
 	 * @param resolver how to resolve paths
@@ -109,7 +154,23 @@ public class Bundler {
 	}
 
 	/**
-	 * Bundles the module at the specified path using the default resolver and loaders
+	 * Bundles the module provided as a parsed Module along with its dependencies and returns the resulting
+	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
+	 * of its input map, and the resolver and loader are well-behaved, uses DEFAULT_OPTIONS.
+	 * @param mod the module
+	 * @param filePath path to the module
+	 * @param resolver how to resolve paths
+	 * @param loader how to load modules
+	 * @return the resulting script
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Script bundleModule(@NotNull Module mod, @NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundleModule(BundlerOptions.DEFAULT_OPTIONS, mod, filePath, resolver, loader, bundler);
+	}
+
+	/**
+	 * Bundles the module at the specified path using the default resolver and loaders.
+	 * @param options options object
 	 * @param filePath path to the module
 	 * @return a bundled script with early errors
 	 * @throws ModuleLoaderException
@@ -119,9 +180,20 @@ public class Bundler {
 	}
 
 	/**
+	 * Bundles the module at the specified path using the default resolver and loaders, uses DEFAULT_OPTIONS.
+	 * @param filePath path to the module
+	 * @return a bundled script with early errors
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Pair<Script, ImmutableList<EarlyError>> bundleWithEarlyErrors(@NotNull Path filePath) throws ModuleLoaderException {
+		return bundleWithEarlyErrors(BundlerOptions.DEFAULT_OPTIONS, filePath);
+	}
+
+	/**
 	 * Bundles the module specified by the given path and its dependencies and returns the resulting
 	 * Script.
 	 *
+	 * @param options options object
 	 * @param filePath is the path to the input entry point module.
 	 * @param resolver how to resolve the path
 	 * @param loader   how to load modules
@@ -137,9 +209,24 @@ public class Bundler {
 	}
 
 	/**
+	 * Bundles the module specified by the given path and its dependencies and returns the resulting
+	 * Script, uses DEFAULT_OPTIONS.
+	 *
+	 * @param filePath is the path to the input entry point module.
+	 * @param resolver how to resolve the path
+	 * @param loader   how to load modules
+	 * @return the resulting script with early errors
+	 * @throws ModuleLoaderException when the module fails to load
+	 */
+	public static @NotNull Pair<Script, ImmutableList<EarlyError>> bundleWithEarlyErrors(@NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundleWithEarlyErrors(BundlerOptions.DEFAULT_OPTIONS, filePath, resolver, loader, bundler);
+	}
+
+	/**
 	 * Bundles the module provided as a string and along with its dependencies and returns the resulting
 	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
 	 * of its input map, and the resolver and loader are well-behaved.
+	 * @param options options object
 	 * @param mod the string of the module
 	 * @param filePath path to the module
 	 * @param resolver how to resolve paths
@@ -153,6 +240,55 @@ public class Bundler {
 		} catch (Exception e) {
 			throw new ModuleLoaderException(filePath.toString(), e);
 		}
+	}
+
+	/**
+	 * Bundles the module provided as a string and along with its dependencies and returns the resulting
+	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
+	 * of its input map, and the resolver and loader are well-behaved, uses DEFAULT_OPTIONS.
+	 * @param mod the string of the module
+	 * @param filePath path to the module
+	 * @param resolver how to resolve paths
+	 * @param loader how to load modules
+	 * @return the resulting script with early errors
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Pair<Script, ImmutableList<EarlyError>> bundleStringWithEarlyErrors(@NotNull String mod, @NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundleStringWithEarlyErrors(BundlerOptions.DEFAULT_OPTIONS, mod, filePath, resolver, loader, bundler);
+	}
+
+	/**
+	 * Bundles the module provided as a string and along with its dependencies and returns the resulting
+	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
+	 * of its input map, and the resolver and loader are well-behaved.
+	 * @param options options object
+	 * @param mod the module
+	 * @param filePath path to the module
+	 * @param resolver how to resolve paths
+	 * @param loader how to load modules
+	 * @return the resulting script with early errors
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Pair<Script, ImmutableList<EarlyError>> bundleModuleWithEarlyErrors(@NotNull BundlerOptions options, @NotNull Module mod, @NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		try {
+			return bundler.bundleEntrypointWithEarlyErrors(options, filePath.toString(), loadDependencies(mod, filePath, resolver, loader));
+		} catch (Exception e) {
+			throw new ModuleLoaderException(filePath.toString(), e);
+		}
+	}
+
+	/**
+	 * Bundles the module provided as a string and along with its dependencies and returns the resulting
+	 * Script. Deterministic as long as the bundler has no sources of nondeterminism other than the ordering
+	 * of its input map, and the resolver and loader are well-behaved, uses DEFAULT_OPTIONS.
+	 * @param filePath path to the module
+	 * @param resolver how to resolve paths
+	 * @param loader how to load modules
+	 * @return the resulting script with early errors
+	 * @throws ModuleLoaderException
+	 */
+	public static @NotNull Pair<Script, ImmutableList<EarlyError>> bundleModuleWithEarlyErrors(@NotNull Module mod, @NotNull Path filePath, @NotNull IResolver resolver, @NotNull IResourceLoader loader, IModuleBundler bundler) throws ModuleLoaderException {
+		return bundleModuleWithEarlyErrors(BundlerOptions.DEFAULT_OPTIONS, mod, filePath, resolver, loader, bundler);
 	}
 
 	/**

--- a/src/main/java/com/shapesecurity/bandolier/es2017/Main.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/Main.java
@@ -1,9 +1,10 @@
 package com.shapesecurity.bandolier.es2017;
 
-import com.shapesecurity.bandolier.es2017.bundlers.StandardModuleBundler;
-import com.shapesecurity.bandolier.es2017.loader.NodeResolver;
+import com.shapesecurity.bandolier.es2017.bundlers.BundlerOptions;
+import com.shapesecurity.bandolier.es2017.bundlers.PiercedModuleBundler;
 import com.shapesecurity.bandolier.es2017.loader.FileLoader;
 import com.shapesecurity.bandolier.es2017.loader.IResourceLoader;
+import com.shapesecurity.bandolier.es2017.loader.NodeResolver;
 import com.shapesecurity.shift.es2017.ast.Script;
 import com.shapesecurity.shift.es2017.codegen.CodeGen;
 
@@ -13,10 +14,10 @@ public class Main {
 	public static void main(String[] args) throws Exception {
 		if (args.length > 0) {
 			IResourceLoader loader = new FileLoader();
-			Script bundle = Bundler.bundle(Paths.get(args[0]).toAbsolutePath(),
+			Script bundle = Bundler.bundle(BundlerOptions.NODE_OPTIONS, Paths.get(args[0]).toAbsolutePath(),
 										   new NodeResolver(loader),
-										   loader, new StandardModuleBundler());
-			System.out.print(CodeGen.codeGen(bundle));
+										   loader, new PiercedModuleBundler());
+			System.out.println(CodeGen.codeGen(bundle));
 		} else {
 			System.err.println("Must provide a filename");
 		}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
@@ -1,0 +1,59 @@
+package com.shapesecurity.bandolier.es2017.bundlers;
+
+import javax.annotation.Nonnull;
+
+public final class BundlerOptions {
+
+	public enum ImportUnresolvedResolutionStrategy {
+		COMPILE_ERROR,
+		DEFAULT_TO_UNDEFINED,
+		THROW_ON_REFERENCE,
+		NOTHING
+	}
+
+	public enum ExportStrategy {
+		EXPLICIT,
+		ALL_GLOBALS
+	}
+
+	public enum DangerLevel {
+		SAFE, // to spec, should be used unless one wants compile errors when optimizations are impossible (or depends on Module[Symbol.toStringTag] behavior)
+		BALANCED, // removes TDZ handling, Symbol.toStringTag, throwOnCircularDependency provides greedy safety for TDZ removal, however, Symbol.toStringTag remains unsafe.
+		DANGEROUS // removes read-only protection for imports, does nothing over BALANCED with throwOnImportAssignment enabled.
+	}
+
+	@Nonnull
+	public final ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy;
+	@Nonnull
+	public final ExportStrategy exportStrategy;
+	@Nonnull
+	public final DangerLevel dangerLevel;
+	public final boolean throwOnCircularDependency;
+	public final boolean throwOnImportAssignment;
+
+
+	private BundlerOptions(@Nonnull ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy, @Nonnull ExportStrategy exportStrategy, @Nonnull DangerLevel dangerLevel, boolean throwOnCircularDependency, boolean throwOnImportAssignment) {
+		this.importUnresolvedResolutionStrategy = importUnresolvedResolutionStrategy;
+		this.exportStrategy = exportStrategy;
+		this.dangerLevel = dangerLevel;
+		this.throwOnCircularDependency = throwOnCircularDependency;
+		this.throwOnImportAssignment = throwOnImportAssignment;
+	}
+
+	public static final BundlerOptions NODE_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.DEFAULT_TO_UNDEFINED, ExportStrategy.ALL_GLOBALS, DangerLevel.SAFE, false, false);
+
+	public static final BundlerOptions SPEC_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, false, false);
+
+	public BundlerOptions withDangerLevel(@Nonnull DangerLevel dangerLevel) {
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+	}
+
+	public BundlerOptions withThrowOnCircularDependency(boolean throwOnCircularDependency) {
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+	}
+
+	public BundlerOptions withThrowOnImportAssignment(boolean throwOnImportAssignment) {
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+	}
+
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
@@ -32,7 +32,7 @@ public final class BundlerOptions {
 	public final boolean throwOnImportAssignment;
 
 
-	private BundlerOptions(@Nonnull ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy, @Nonnull ExportStrategy exportStrategy, @Nonnull DangerLevel dangerLevel, boolean throwOnCircularDependency, boolean throwOnImportAssignment) {
+	public BundlerOptions(@Nonnull ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy, @Nonnull ExportStrategy exportStrategy, @Nonnull DangerLevel dangerLevel, boolean throwOnCircularDependency, boolean throwOnImportAssignment) {
 		this.importUnresolvedResolutionStrategy = importUnresolvedResolutionStrategy;
 		this.exportStrategy = exportStrategy;
 		this.dangerLevel = dangerLevel;
@@ -43,6 +43,8 @@ public final class BundlerOptions {
 	public static final BundlerOptions NODE_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.DEFAULT_TO_UNDEFINED, ExportStrategy.ALL_GLOBALS, DangerLevel.SAFE, false, false);
 
 	public static final BundlerOptions SPEC_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, false, false);
+
+	public static final BundlerOptions DEFAULT_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, true, true);
 
 	public BundlerOptions withDangerLevel(@Nonnull DangerLevel dangerLevel) {
 		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/IModuleBundler.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/IModuleBundler.java
@@ -1,13 +1,18 @@
 package com.shapesecurity.bandolier.es2017.bundlers;
 
+import com.shapesecurity.shift.es2017.parser.EarlyError;
 import com.shapesecurity.shift.es2017.ast.Script;
 import com.shapesecurity.shift.es2017.ast.Module;
-
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.data.ImmutableList;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Map;
 
 public interface IModuleBundler {
 	@NotNull
-	Script bundleEntrypoint(String entry, Map<String, Module> modules) throws Exception;
+	Script bundleEntrypoint(BundlerOptions options, String entry, Map<String, Module> modules) throws Exception;
+
+	@NotNull
+	Pair<Script, ImmutableList<EarlyError>> bundleEntrypointWithEarlyErrors(BundlerOptions options, String entry, Map<String, Module> modules) throws Exception;
 }

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/PiercedModuleBundler.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/PiercedModuleBundler.java
@@ -1,0 +1,39 @@
+package com.shapesecurity.bandolier.es2017.bundlers;
+
+import com.shapesecurity.bandolier.es2017.transformations.ImportExportConnector;
+import com.shapesecurity.bandolier.es2017.transformations.VariableCollisionResolver;
+import com.shapesecurity.bandolier.es2017.transformations.VariableNameGenerator;
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.Tuple3;
+import com.shapesecurity.functional.data.HashTable;
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.shift.es2017.ast.Module;
+import com.shapesecurity.shift.es2017.ast.Script;
+import com.shapesecurity.shift.es2017.parser.EarlyError;
+import com.shapesecurity.shift.es2017.parser.EarlyErrorChecker;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+// merges modules by resolving variable collision, scheduling, and merging modules.
+public class PiercedModuleBundler implements IModuleBundler {
+
+	@Override
+	public @NotNull Script bundleEntrypoint(BundlerOptions options, String entry, Map<String, Module> modules) {
+		HashTable<String, Module> newModules = HashTable.emptyUsingEquality();
+		for (Map.Entry<String, Module> mapEntry : modules.entrySet()) {
+			newModules = newModules.put(mapEntry.getKey(), mapEntry.getValue());
+		}
+		Tuple3<HashTable<String, Module>, VariableNameGenerator, HashTable<Module, HashTable<String, String>>> tuple = VariableCollisionResolver.resolveCollisions(newModules);
+		Script script = ImportExportConnector.combineModules(options, tuple.a.get(entry).fromJust(), tuple.b, tuple.a, tuple.c);
+		return script;
+	}
+
+
+
+	@Override
+	public @NotNull Pair<Script, ImmutableList<EarlyError>> bundleEntrypointWithEarlyErrors(BundlerOptions options, String entry, Map<String, Module> modules) {
+		return Pair.of(bundleEntrypoint(options, entry, modules), ImmutableList.from(modules.values().stream().map(EarlyErrorChecker::validate).collect(Collectors.toList())).foldLeft(ImmutableList::append, ImmutableList.empty()));
+	}
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/GlobalVariableExtractor.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/GlobalVariableExtractor.java
@@ -1,0 +1,120 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.Maybe;
+import com.shapesecurity.functional.data.MultiHashTable;
+import com.shapesecurity.shift.es2017.ast.*;
+import com.shapesecurity.shift.es2017.ast.Module;
+import com.shapesecurity.shift.es2017.reducer.Director;
+import com.shapesecurity.shift.es2017.reducer.MonoidalReducer;
+import com.shapesecurity.shift.es2017.scope.GlobalScope;
+import com.shapesecurity.shift.es2017.scope.ScopeAnalyzer;
+import com.shapesecurity.shift.es2017.scope.ScopeLookup;
+import com.shapesecurity.shift.es2017.scope.Variable;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.stream.Collectors;
+
+// determines all declared global variables for a module, linked to a scope analysis variable
+public class GlobalVariableExtractor {
+
+	private GlobalVariableExtractor() {
+
+	}
+
+	public static MultiHashTable<String, Variable> extractAllDeclaredVariables(@Nonnull Module module, @Nonnull GlobalScope globalScope, @Nonnull ScopeLookup lookup) {
+		DeclaredVariableReducer reducer = new DeclaredVariableReducer(globalScope, lookup);
+		return Director.reduceModule(reducer, module);
+	}
+
+	public static MultiHashTable<String, Variable> extractAllDeclaredVariables(@Nonnull Module module) {
+		GlobalScope globalScope = ScopeAnalyzer.analyze(module);
+		return extractAllDeclaredVariables(module, globalScope, new ScopeLookup(globalScope));
+	}
+
+	private static final class DeclaredVariableReducer extends MonoidalReducer<MultiHashTable<String, Variable>>  {
+
+		@Nonnull
+		private final ScopeLookup lookup;
+		@Nonnull
+		private final GlobalScope globalScope;
+
+		public DeclaredVariableReducer(@Nonnull GlobalScope globalScope, @Nonnull ScopeLookup lookup) {
+			super(new MonoidMultiHashTableEqualityMerge<>());
+			this.lookup = lookup;
+			this.globalScope = globalScope;
+		}
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceBindingIdentifier(@Nonnull BindingIdentifier node) {
+			if (node.name.equals("*default*")) {
+				return this.identity();
+			}
+			Maybe<Variable> maybeVariable = lookup.findVariableDeclaredBy(node);
+			if (maybeVariable.isJust()) {
+				return this.identity().put(node.name, maybeVariable.fromJust());
+			}
+			List<Variable> matchingUndeclaredGlobals = globalScope.variables().stream().filter(variable -> variable.declarations.length == 0 && variable.name.equals(node.name)).collect(Collectors.toList());
+			if (matchingUndeclaredGlobals.size() == 1) {
+				return this.identity().put(node.name, matchingUndeclaredGlobals.get(0)); // this handles imports which define a variable but not declare it? scope analysis bug?
+			} else {
+				throw new RuntimeException("Unable to handle rogue binding identifier, " + matchingUndeclaredGlobals.size() + " matching candidates for non-declared definitions. (you are probably missing a module)");
+			}
+		}
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceImport(
+				@Nonnull Import node,
+				@Nonnull Maybe<MultiHashTable<String, Variable>> defaultBinding,
+				@Nonnull ImmutableList<MultiHashTable<String, Variable>> namedImports) {
+			return MultiHashTable.emptyUsingEquality();
+		}
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceImportNamespace(
+				@Nonnull ImportNamespace node,
+				@Nonnull Maybe<MultiHashTable<String, Variable>> defaultBinding,
+				@Nonnull MultiHashTable<String, Variable> namespaceBinding) {
+			return MultiHashTable.emptyUsingEquality();
+		}
+
+		// we don't care about sub function scopes
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceFunctionBody(
+				@Nonnull FunctionBody node,
+				@Nonnull ImmutableList<MultiHashTable<String, Variable>> directives,
+				@Nonnull ImmutableList<MultiHashTable<String, Variable>> statements) {
+			return MultiHashTable.emptyUsingEquality();
+		}
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceFormalParameters(
+				@Nonnull FormalParameters node,
+				@Nonnull ImmutableList<MultiHashTable<String, Variable>> items,
+				@Nonnull Maybe<MultiHashTable<String, Variable>> rest) {
+			return MultiHashTable.emptyUsingEquality();
+		}
+
+		@Nonnull
+		@Override
+		public MultiHashTable<String, Variable> reduceBlock(
+				@Nonnull Block node,
+				@Nonnull ImmutableList<MultiHashTable<String, Variable>> statements) {
+			MultiHashTable<String, Variable> table = fold(statements);
+			MultiHashTable<String, Variable> returning = MultiHashTable.emptyUsingEquality();
+			// filter
+			for (Pair<String, ImmutableList<Variable>> pair : table.entries()) {
+				returning = pair.right.foldLeft(((acc, var) -> var.declarations.exists((decl) -> decl.kind.isFunctionScoped) ? acc.put(pair.left, var) : acc), returning);
+			}
+			return returning;
+		}
+	}
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -1,0 +1,795 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.bandolier.es2017.bundlers.BundlerOptions;
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.Tuple3;
+import com.shapesecurity.functional.data.*;
+import com.shapesecurity.shift.es2017.ast.*;
+import com.shapesecurity.shift.es2017.ast.Module;
+import com.shapesecurity.shift.es2017.ast.operators.BinaryOperator;
+import com.shapesecurity.shift.es2017.ast.operators.UnaryOperator;
+import com.shapesecurity.shift.es2017.path.BranchGetter;
+import com.shapesecurity.shift.es2017.path.BranchIterator;
+import com.shapesecurity.shift.es2017.reducer.Director;
+import com.shapesecurity.shift.es2017.reducer.Reducer;
+import com.shapesecurity.shift.es2017.reducer.WrappedReducer;
+import com.shapesecurity.shift.es2017.scope.*;
+
+import javax.annotation.Nonnull;
+import java.util.*;
+
+// connects a list of modules via import/export statements.
+public class ImportExportConnector {
+
+	private ImportExportConnector() {
+
+	}
+
+	/**
+	 *
+	 * Recursively extracts bindings. Used to resolve exports of object/array bindings.
+	 *
+	 * @param localExported current module-local exports
+	 * @param export current export declaration
+	 * @param binding current binding
+	 * @param lookup global scope lookup
+	 * @return a new module-local export list
+	 */
+	private static HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> handleBinding(@Nonnull HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> localExported, @Nonnull ExportDeclaration export, @Nonnull BindingBindingWithDefault binding, @Nonnull ScopeLookup lookup, @Nonnull HashTable<String, String> exportNames) {
+		if (binding instanceof BindingIdentifier) {
+			Variable variable = lookup.findVariableDeclaredBy((BindingIdentifier) binding).fromJust();
+			localExported = localExported.put(exportNames.get(variable.name).orJust(variable.name), HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of(export, variable)));
+		} else if (binding instanceof ObjectBinding) {
+			for (BindingProperty property : ((ObjectBinding) binding).properties) {
+				if (property instanceof BindingPropertyIdentifier) {
+					Variable variable = lookup.findVariableDeclaredBy(((BindingPropertyIdentifier) property).binding).fromJust();
+					localExported = localExported.put(exportNames.get(variable.name).orJust(variable.name), HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of(export, variable)));
+				} else if (property instanceof BindingPropertyProperty) {
+					localExported = handleBinding(localExported, export, ((BindingPropertyProperty) property).binding, lookup, exportNames);
+				}
+			}
+		} else if (binding instanceof ArrayBinding) {
+			for (Maybe<BindingBindingWithDefault> maybeBinding : ((ArrayBinding) binding).elements) {
+				if (maybeBinding.isNothing()) {
+					continue;
+				}
+				BindingBindingWithDefault subBinding = maybeBinding.fromJust();
+				if (subBinding instanceof BindingPropertyIdentifier) {
+					Variable variable = lookup.findVariableDeclaredBy(((BindingPropertyIdentifier) subBinding).binding).fromJust();
+					localExported = localExported.put(exportNames.get(variable.name).orJust(variable.name), HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of(export, variable)));
+				} else if (subBinding instanceof BindingWithDefault) {
+					localExported = handleBinding(localExported, export, ((BindingWithDefault) subBinding).binding, lookup, exportNames);
+				}
+			}
+		}
+		return localExported;
+	}
+
+	/**
+	 *
+	 * Recursively extracts binding identifiers from a binding.
+	 *
+	 * @param binding current binding
+	 * @param bindings current bindings
+	 * @return a new module-local export list
+	 */
+	private static ImmutableSet<String> extractBindings(@Nonnull BindingBindingWithDefault binding, @Nonnull ImmutableSet<String> bindings) {
+		if (binding instanceof BindingIdentifier) {
+			bindings = bindings.put(((BindingIdentifier) binding).name);
+		} else if (binding instanceof ObjectBinding) {
+			for (BindingProperty property : ((ObjectBinding) binding).properties) {
+				if (property instanceof BindingPropertyIdentifier) {
+					bindings = bindings.put(((BindingPropertyIdentifier) property).binding.name);
+				} else if (property instanceof BindingPropertyProperty) {
+					bindings = extractBindings(((BindingPropertyProperty) property).binding, bindings);
+				}
+			}
+		} else if (binding instanceof ArrayBinding) {
+			for (Maybe<BindingBindingWithDefault> maybeBinding : ((ArrayBinding) binding).elements) {
+				if (maybeBinding.isNothing()) {
+					continue;
+				}
+				BindingBindingWithDefault subBinding = maybeBinding.fromJust();
+				if (subBinding instanceof BindingPropertyIdentifier) {
+					bindings = bindings.put(((BindingPropertyIdentifier) subBinding).binding.name);
+				} else if (subBinding instanceof BindingWithDefault) {
+					bindings = extractBindings(((BindingWithDefault) subBinding).binding, bindings);
+				}
+			}
+		}
+		return bindings;
+	}
+
+	/**
+	 * Resolves an import to a globally scoped variable.
+	 *
+	 * @param exported all exports
+	 * @param module current module
+	 * @param name import specifier
+	 * @return variable of export, safe to reference
+	 */
+	private static Maybe<Variable> resolveImport(@Nonnull HashTable<Module, HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>> exported,
+										  @Nonnull Module module,
+										  @Nonnull String name) {
+		Maybe<HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> table = exported.get(module).fromJust().get(name);
+		if (table.isNothing()) {
+			return Maybe.empty();
+		}
+		return table.map(map -> map.iterator().next().right.right);
+	}
+
+	/**
+	 * This method is responsible for resolving proxy export statements such as:
+	 *```
+	 * 		export * from './module.js'
+	 *```
+	 * or
+	 *```
+	 * 		export {myVar} from './module.js'
+	 *```
+	 * by merging the `extracted` and `renamingMap` tables as appropriate.
+	 *
+	 * @param module current working module
+	 * @param exported global export mapping
+	 * @param globalExportsDesired a map of all global proxy exports, requester to source
+	 * @param specificExportsDesired a map of all specific proxy exports, requester to name to source
+	 * @param updated a current set of modules which have been invalidated in the current iteration of all or updated modules. this will be iterated on the next round.
+	 * @param renamingMap the current renaming map of original modules, with modification applied via the merging in this method. used to resolve specifiers in differing modules.
+	 * @return a tuple of a new exported table, updated set, and new renaming map, respectively.
+	 */
+	private static Tuple3<HashTable<Module, HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>>, ImmutableSet<Module>, HashTable<Module, HashTable<String, String>>> resolveProxyExports(
+			@Nonnull Module module,
+			@Nonnull HashTable<Module, HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>> exported,
+			@Nonnull MultiHashTable<Module, Module> globalExportsDesired,
+			@Nonnull HashTable<Module, MultiHashTable<String, Pair<Module, Maybe<String>>>> specificExportsDesired,
+			@Nonnull ImmutableSet<Module> updated,
+			@Nonnull HashTable<Module, HashTable<String, String>> renamingMap) {
+		HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> moduleExported = exported.get(module).fromJust();
+		ImmutableList<Module> wantAll = globalExportsDesired.get(module);
+		HashTable<String, String> ourRenamingMap = renamingMap.get(module).fromJust();
+		for (Module wantingModule : wantAll) {
+			HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> wantingExported = exported.get(wantingModule).orJust(HashTable.emptyUsingEquality());
+
+			boolean update = false;
+			for (Pair<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> pair : moduleExported) {
+				if (!pair.left.equals("default") && (!wantingExported.containsKey(pair.left) || !wantingExported.get(pair.left).fromJust().containsKey(Maybe.of(module)))) {
+					wantingExported = wantingExported.put(pair.left, pair.right.foldLeft((acc, subPair) -> acc.put(Maybe.of(module), subPair.right), wantingExported.get(pair.left).orJust(HashTable.emptyUsingEquality())));
+					update = true;
+				}
+			}
+			if (update) {
+				exported = exported.put(wantingModule, wantingExported);
+				updated = updated.put(wantingModule);
+				renamingMap = renamingMap.put(wantingModule, renamingMap.get(wantingModule).fromJust().merge(ourRenamingMap));
+			}
+		}
+		MultiHashTable<String, Pair<Module, Maybe<String>>> subExports = specificExportsDesired.get(module).orJust(MultiHashTable.emptyUsingEquality());
+		for (Pair<String, ImmutableList<Pair<Module, Maybe<String>>>> exports : subExports.entries()) {
+			Maybe<HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> maybeLocalExported = moduleExported.get(exports.left);
+			if (maybeLocalExported.isNothing()) {
+				continue; // should become available in later iterations
+			}
+			HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>> localExported = maybeLocalExported.fromJust();
+			// the following search is not ideal, but adding an inverse map in this case, would probably be slower.
+			Maybe<Pair<String, String>> ourMapping = ourRenamingMap.find(pair -> pair.right.equals(exports.left));
+			for (Pair<Module, Maybe<String>> exportInfo : exports.right) {
+				HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> wantingExported = exported.get(exportInfo.left).orJust(HashTable.emptyUsingEquality());
+				String exportName = exportInfo.right.orJust(exports.left);
+				if (!wantingExported.containsKey(exportName)) {
+					exported = exported.put(exportInfo.left, wantingExported.put(exportName, wantingExported.get(exportName).orJust(HashTable.emptyUsingEquality()).merge(localExported)));
+					updated = updated.put(exportInfo.left);
+					if (ourMapping.isJust()) {
+						renamingMap = renamingMap.put(exportInfo.left, renamingMap.get(exportInfo.left).fromJust().put(ourMapping.fromJust().left, ourMapping.fromJust().right));
+					}
+				}
+			}
+		}
+		return new Tuple3<>(exported, updated, renamingMap);
+	}
+
+	private enum ModuleState {
+		INSTANTIATING, INSTANTIATED, ERROR
+	}
+
+	/**
+	 * Schedules each module according to the proper execution order.
+	 *
+	 * @param module entrypoint module to schedule. (always executed last)
+	 * @param schedule mutable list for schedule to be added onto
+	 * @param scheduleSet already scheduled modules
+	 * @param dependingOn mapping of module dependencies
+	 * @param index internal counter, always initialise to 0
+	 * @param stack internal stack for scheduling, always initialise to empty list
+	 * @param stackSet internal set for scheduling, always initialise to empty set
+	 * @param moduleAncestorIndex  internal counter, always initialise to 0
+	 * @return an index and state of a module scheduled. the index is used internally, and is to be discarded. success can be determined by checking the module state is `ModuleState.INSTANTIATED`
+	 */
+	private static Pair<Integer, ModuleState> scheduleModule(@Nonnull Module module, @Nonnull LinkedList<Module> schedule, @Nonnull HashSet<Module> scheduleSet, @Nonnull HashMap<Module, LinkedList<Module>> dependingOn, int index, @Nonnull LinkedList<Module> stack, @Nonnull HashSet<Module> stackSet, @Nonnull HashMap<Module, Integer> moduleAncestorIndex) {
+		if (scheduleSet.contains(module)) {
+			return Pair.of(index, ModuleState.INSTANTIATED);
+		} else if (stackSet.contains(module)) {
+			return Pair.of(index, ModuleState.INSTANTIATING);
+		}
+		stack.push(module);
+		stackSet.add(module);
+		moduleAncestorIndex.put(module, index);
+		int originalIndex = index;
+		++index;
+		LinkedList<Module> children = dependingOn.get(module);
+		if (children != null) {
+			Iterator<Module> subModules = children.descendingIterator();
+			while (subModules.hasNext()) {
+				Module subModule = subModules.next();
+				Pair<Integer, ModuleState> pair = scheduleModule(subModule, schedule, scheduleSet, dependingOn, index, stack, stackSet, moduleAncestorIndex);
+				index = pair.left;
+				if (pair.right == ModuleState.INSTANTIATING) {
+					if (!stackSet.contains(subModule)) {
+						return Pair.of(-1, ModuleState.ERROR);
+					}
+					int ancestorIndex = moduleAncestorIndex.get(module);
+					int subAncestorIndex = moduleAncestorIndex.get(subModule);
+					if (subAncestorIndex < ancestorIndex) {
+						ancestorIndex = subAncestorIndex;
+					}
+					moduleAncestorIndex.put(module, ancestorIndex);
+				} else if (pair.right == ModuleState.ERROR) {
+					return Pair.of(-1, ModuleState.ERROR);
+				}
+			}
+		}
+		int ancestorIndex = moduleAncestorIndex.get(module);
+		if (ancestorIndex > originalIndex || stack.stream().filter(subModule -> subModule.equals(module)).count() != 1) {
+			return Pair.of(-1, ModuleState.ERROR);
+		}
+		if (ancestorIndex == originalIndex) {
+			Module subModule;
+			do {
+				if (stack.size() == 0) {
+					return Pair.of(-1, ModuleState.ERROR);
+				}
+				subModule = stack.pop();
+				scheduleSet.add(subModule);
+				schedule.add(subModule);
+			} while (!subModule.equals(module));
+		}
+		return Pair.of(index, ModuleState.INSTANTIATED);
+	}
+
+	private static ImmutableSet<Module> recurRecursiveDependencyChecker(@Nonnull Module module, @Nonnull HashSet<Module> nonSelfReferentialModules, @Nonnull HashMap<Module, LinkedList<Module>> dependingOn, @Nonnull ImmutableSet<Module> recurring) {
+		if (recurring.contains(module)) {
+			return ImmutableSet.<Module>emptyUsingIdentity().put(module);
+		}
+		LinkedList<Module> dependingOnLocal = dependingOn.get(module);
+		if (dependingOnLocal == null) {
+			nonSelfReferentialModules.add(module);
+			return ImmutableSet.emptyUsingIdentity();
+		}
+		ImmutableSet<Module> dependencies = ImmutableList.from(dependingOnLocal).uniqByIdentity();
+		ImmutableSet<Module> subDependencies = dependencies;
+		ImmutableSet<Module> subRecurring = recurring.put(module);
+		for (Module subModule : dependencies) {
+			subDependencies = subDependencies.union(recurRecursiveDependencyChecker(subModule, nonSelfReferentialModules, dependingOn, subRecurring));
+		}
+
+		for (Module subDependency : subDependencies) {
+			if (subRecurring.contains(subDependency)) {
+				return subDependencies;
+			}
+		}
+		nonSelfReferentialModules.add(module);
+		return subDependencies;
+	}
+
+	/**
+	 * combines a set of modules, given a VariableNameGenerator guaranteed not to have collisions or errors, and a map of previous bound renaming, to satisfy importing.
+	 *
+	 * @param entry entrypoint module
+	 * @param nameGenerator guaranteed not to produce collisions, in any module.
+	 * @param modules mapping of path to modules for combination
+	 * @param originalRenamingMap a per-module renaming map that has been applied from the original modules. used to satisfy cross-module failures due to importing.
+	 * @return a complete script
+	 */
+	public static Script combineModules(@Nonnull BundlerOptions options, @Nonnull Module entry, @Nonnull VariableNameGenerator nameGenerator, @Nonnull HashTable<String, Module> modules, @Nonnull HashTable<Module, HashTable<String, String>> originalRenamingMap) {
+		// lookups per module
+		HashTable<Module, GlobalScope> globalScopes = modules.foldLeft((acc, pair) -> acc.put(pair.right, ScopeAnalyzer.analyze(pair.right)), HashTable.emptyUsingEquality());
+		HashTable<Module, ScopeLookup> lookups = modules.foldLeft((acc, pair) -> acc.put(pair.right, new ScopeLookup(globalScopes.get(pair.right).fromJust())), HashTable.emptyUsingEquality());
+		// all exported variables, per module, tracks the export the import was delivered from.
+		HashTable<Module, HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>> exported = HashTable.emptyUsingIdentity();
+		// namespace proxy export requests
+		MultiHashTable<Module, Module> globalExportsDesired = MultiHashTable.emptyUsingIdentity();
+		// named proxy export requests
+		HashTable<Module, MultiHashTable<String, Pair<Module, Maybe<String>>>> specificExportsDesired = HashTable.emptyUsingIdentity();
+		// current renaming map, to be applied at end
+		HashTable<String, String> renamingMap = HashTable.emptyUsingEquality();
+		// map of exports to names for default exports.
+		IdentityHashMap<ExportDefault, String> exportExpressionNames = new IdentityHashMap<>();
+
+		HashTable<Module, HashTable<String, String>> invertedOriginalRenamingMaps = originalRenamingMap.map(map -> map.foldLeft((acc, pair) -> acc.put(pair.right, pair.left), HashTable.emptyUsingEquality()));
+
+		// perform initial export extraction and prepare for proxy export resolution
+		for (Pair<String, Module> pair : modules) {
+			ScopeLookup lookup = lookups.get(pair.right).fromJust();
+			HashTable<String, String> exportNames = invertedOriginalRenamingMaps.get(pair.right).fromJust();//
+			HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> localExported = exported.get(pair.right).orJust(HashTable.emptyUsingEquality());
+
+			for (ImportDeclarationExportDeclarationStatement item : pair.right.items) {
+				if (item instanceof ExportAllFrom) {
+					Module from = modules.get(((ExportAllFrom) item).moduleSpecifier).fromJust();
+					globalExportsDesired = globalExportsDesired.put(from, pair.right);
+				} else if (item instanceof ExportFrom) {
+					Module from = modules.get(((ExportFrom) item).moduleSpecifier).fromJust();
+					specificExportsDesired = ((ExportFrom) item).namedExports
+							.foldLeft((acc, name) ->
+									acc.put(from, acc.get(from).orJust(MultiHashTable.emptyUsingEquality()).put(name.name, Pair.of(pair.right, name.exportedName)))
+							, specificExportsDesired);
+				} else if (item instanceof ExportLocals) {
+					for (ExportLocalSpecifier specifier : ((ExportLocals) item).namedExports) {
+						Variable referencedVariable = lookup.findVariableReferencedBy(specifier.name);
+						String name = specifier.exportedName.orJust(specifier.name.name);
+						name = exportNames.get(name).orJust(name);
+						localExported = localExported.put(name, HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, referencedVariable)));
+					}
+				} else if (item instanceof Export) {
+					FunctionDeclarationClassDeclarationVariableDeclaration declaration = ((Export) item).declaration;
+					if (declaration instanceof FunctionDeclaration) {
+						Variable variable = lookup.findVariableDeclaredBy(((FunctionDeclaration) declaration).name).fromJust();
+						String name = variable.name;
+						name = exportNames.get(name).orJust(name);
+						localExported = localExported.put(name, HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, variable)));
+					} else if (declaration instanceof ClassDeclaration) {
+						Variable variable = lookup.findVariableDeclaredBy(((ClassDeclaration) declaration).name).fromJust();
+						String name = variable.name;
+						name = exportNames.get(name).orJust(name);
+						localExported = localExported.put(name, HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, variable)));
+					} else if (declaration instanceof VariableDeclaration) {
+						for (VariableDeclarator declarator : ((VariableDeclaration) declaration).declarators) {
+							localExported = handleBinding(localExported, (ExportDeclaration) item, declarator.binding, lookup, exportNames);
+						}
+					} else {
+						throw new RuntimeException("Not reached");
+					}
+				} else if (item instanceof ExportDefault) {
+					FunctionDeclarationClassDeclarationExpression body = ((ExportDefault) item).body;
+					if (body instanceof FunctionDeclaration) {
+						BindingIdentifier identifier = ((FunctionDeclaration) body).name;
+						exportExpressionNames.put((ExportDefault) item, identifier.name);
+						Variable variable = lookup.findVariableDeclaredBy(identifier).fromJust();
+						localExported = localExported.put("default", HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, variable)));
+					} else if (body instanceof ClassDeclaration) {
+						Variable variable = lookup.findVariableDeclaredBy(((ClassDeclaration) body).name).fromJust();
+						exportExpressionNames.put((ExportDefault) item, ((ClassDeclaration) body).name.name);
+						localExported = localExported.put("default", HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, variable)));
+					} else {
+						String name = nameGenerator.next();
+						exportExpressionNames.put((ExportDefault) item, name);
+						localExported = localExported.put("default", HashTable.<Maybe<Module>, Pair<ExportDeclaration, Variable>>emptyUsingEquality().put(Maybe.empty(), Pair.of((ExportDeclaration) item, new Variable(name, ImmutableList.empty(), ImmutableList.of(new Declaration(new BindingIdentifier(name), Declaration.Kind.Var))))));
+					}
+				}
+			}
+
+			exported = exported.put(pair.right, localExported);
+		}
+
+		// name of global object for resolving internal usage of standard JS APIs
+		String globalBinding = nameGenerator.next();
+
+		// proxy export resolution
+		if (globalExportsDesired.entries().length > 0 || specificExportsDesired.length > 0) {
+			// prepare for proxy export resolution
+			final MultiHashTable<Module, Module> finalGlobalExportsDesired = globalExportsDesired;
+			final HashTable<Module, MultiHashTable<String, Pair<Module, Maybe<String>>>> finalSpecificExportsDesired = specificExportsDesired;
+			ImmutableSet<Module> updated = exported.keys().foldAbelian((module, acc) -> finalGlobalExportsDesired.get(module).isNotEmpty() || finalSpecificExportsDesired.get(module).isJust() ? acc.put(module) : acc, ImmutableSet.emptyUsingIdentity());
+			boolean someUpdate = false;
+			// iterate while we have any potentially erroneous resolved modules.
+			while (updated.length() > 0) {
+				ImmutableSet<Module> nextUpdated = ImmutableSet.emptyUsingIdentity();
+				for (Module module : updated) {
+					someUpdate = true;
+					// see resolveProxyExports for specifics.
+					Tuple3<HashTable<Module, HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>>, ImmutableSet<Module>, HashTable<Module, HashTable<String, String>>> tuple = resolveProxyExports(module, exported, globalExportsDesired, specificExportsDesired, nextUpdated, originalRenamingMap);
+					exported = tuple.a;
+					nextUpdated = nextUpdated.union(tuple.b);
+					originalRenamingMap = tuple.c;
+				}
+				updated = nextUpdated;
+			}
+			if (someUpdate) {
+				invertedOriginalRenamingMaps = originalRenamingMap.map(map -> map.foldLeft((acc, pair) -> acc.put(pair.right, pair.left), HashTable.emptyUsingEquality()));
+			}
+			for (Pair<Module, MultiHashTable<String, Pair<Module, Maybe<String>>>> subExports : specificExportsDesired) {
+				for (Pair<String, ImmutableList<Pair<Module, Maybe<String>>>> exports : subExports.right.entries()) {
+					Maybe<HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> maybeLocalExported = exported.get(subExports.left).fromJust().get(exports.left);
+					if (maybeLocalExported.isNothing()) {
+						throw new RuntimeException("Unresolved proxy export");
+					}
+				}
+			}
+
+		}
+
+		// build dependency graph
+		HashMap<Module, HashSet<Module>> dependedBy = new HashMap<>();
+		HashMap<Module, LinkedList<Module>> dependingOn = new HashMap<>();
+		for (Pair<String, Module> pair : modules) {
+			LinkedList<Module> dependents = null;
+			for (ImportDeclarationExportDeclarationStatement item : pair.right.items) {
+				if (item instanceof ImportDeclaration || item instanceof ExportFrom || item instanceof ExportAllFrom) {
+					if (dependents == null) {
+						dependents = dependingOn.computeIfAbsent(pair.right, mod -> new LinkedList<>());
+					}
+					String moduleSpecifier;
+					if (item instanceof ImportDeclaration) {
+						moduleSpecifier = ((ImportDeclaration) item).moduleSpecifier;
+					} else if (item instanceof ExportFrom) {
+						moduleSpecifier = ((ExportFrom) item).moduleSpecifier;
+					} else {
+						moduleSpecifier = ((ExportAllFrom) item).moduleSpecifier;
+					}
+					Module from = modules.get(moduleSpecifier).fromJust();
+					dependedBy.computeIfAbsent(from, mod -> new HashSet<>()).add(pair.right);
+					dependents.add(from);
+				}
+			}
+		}
+
+		// schedule all modules, see https://tc39.github.io/ecma262/#sec-innermoduleinstantiation
+		// note that export name pre-binding is accomplished by name hoisting of function-scoped declarations.
+
+		LinkedList<Module> schedule = new LinkedList<>();
+		Pair<Integer, ModuleState> result = scheduleModule(entry, schedule, new HashSet<>(), dependingOn, 0, new LinkedList<>(), new HashSet<>(), new HashMap<>());
+		if (result.right != ModuleState.INSTANTIATED) {
+			throw new RuntimeException("Failed to schedule modules.");
+		}
+
+		// ensure we scheduled everything -- modules will not be loaded if not imported somewhere.
+		if (schedule.size() != modules.length) {
+			throw new RuntimeException("Not all modules were scheduled: " + schedule.size() + " / " + modules.length + ".");
+		}
+
+		// reference to export object
+		HashTable<Module, String> moduleExportReference = HashTable.emptyUsingIdentity();
+		for (Module module : schedule) {
+			moduleExportReference = moduleExportReference.put(module, nameGenerator.next());
+		}
+
+		// export object property initialisation names
+		HashTable<Module, String> moduleExportDefinedName = HashTable.emptyUsingIdentity();
+		for (Module module : schedule) {
+			moduleExportDefinedName = moduleExportDefinedName.put(module, nameGenerator.next());
+		}
+
+		final HashTable<Module, String> finalModuleExportDefinedName = moduleExportDefinedName;
+
+		MultiHashTable<Module, BindingIdentifier> importedBindings = MultiHashTable.emptyUsingIdentity();
+
+		final HashTable<Module, HashTable<String, String>> inverseExports = exported.foldLeft((acc, pair) -> pair.right.foldLeft((subAcc, subPair) -> subPair.right.foldLeft((subSubAcc, subSubPair) -> subSubAcc.put(pair.left, subSubAcc.get(pair.left).orJustLazy(HashTable::emptyUsingEquality).put(subSubPair.right.right.name, subPair.left)), subAcc), acc), HashTable.emptyUsingIdentity());
+
+		HashSet<VariableReference> unresolvedImportReferences = new HashSet<>();
+
+		HashSet<Module> usedExportModules = new HashSet<>();
+		usedExportModules.add(entry);
+
+		HashSet<Module> nonSelfDependentModules = new HashSet<>();
+
+		recurRecursiveDependencyChecker(entry, nonSelfDependentModules, dependingOn, ImmutableSet.emptyUsingIdentity());
+
+		if (options.throwOnCircularDependency && nonSelfDependentModules.size() != schedule.size()) {
+			throw new RuntimeException("There are " + (schedule.size() - nonSelfDependentModules.size()) + " self-dependent (circular) modules out of " + schedule.size() + ".");
+		}
+
+		// process import naming
+		for (Module module : schedule) {
+			for (ImportDeclarationExportDeclarationStatement item : module.items) {
+				if (item instanceof Import) {
+					Import importItem = (Import) item;
+					Module from = modules.get(importItem.moduleSpecifier).fromJust();
+					if (importItem.defaultBinding.isJust()) {
+						Maybe<Variable> variable = resolveImport(exported, from, "default");
+						if (variable.isNothing()) {
+							if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.COMPILE_ERROR) {
+								throw new RuntimeException("Unresolved import: \"default\"");
+							} else {
+								lookups.get(module).fromJust().findVariableDeclaredBy(importItem.defaultBinding.fromJust()).fromJust().references.map(reference -> reference.node).iterator().forEachRemaining(unresolvedImportReferences::add);
+								continue;
+							}
+						}
+						String name = importItem.defaultBinding.fromJust().name;
+						renamingMap = renamingMap.put(name, variable.fromJust().name);
+						importedBindings = importedBindings.put(module, importItem.defaultBinding.fromJust());
+					}
+					for (ImportSpecifier specifier : importItem.namedImports) {
+						importedBindings = importedBindings.put(module, specifier.binding);
+						if (specifier.name.isJust()) {
+							String specifierName = specifier.name.fromJust();
+							Maybe<Variable> variable = resolveImport(exported, from, specifierName);
+							if (variable.isNothing()) {
+								if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.COMPILE_ERROR) {
+									throw new RuntimeException("Unresolved import: \"" + specifierName + "\"");
+								} else {
+									lookups.get(module).fromJust().findVariableDeclaredBy(specifier.binding).fromJust().references.map(reference -> reference.node).iterator().forEachRemaining(unresolvedImportReferences::add);
+									continue;
+								}
+							}
+							renamingMap = renamingMap.put(specifier.binding.name, variable.fromJust().name);
+						} else {
+							Maybe<Variable> maybeVariable = resolveImport(exported, from, specifier.binding.name);
+							if (maybeVariable.isNothing()) {
+								if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.COMPILE_ERROR) {
+									throw new RuntimeException("Unresolved import: \"" + specifier.binding.name + "\"");
+								} else {
+									lookups.get(module).fromJust().findVariableDeclaredBy(specifier.binding).fromJust().references.map(reference -> reference.node).iterator().forEachRemaining(unresolvedImportReferences::add);
+									continue;
+								}
+							}
+							Variable variable = maybeVariable.fromJust();
+							String name = invertedOriginalRenamingMaps.get(module).fromJust().get(variable.name).orJust(variable.name);
+							if (!specifier.binding.name.equals(name)) {
+								renamingMap = renamingMap.put(specifier.binding.name, variable.name);
+							}
+						}
+					}
+				} else if (item instanceof ImportNamespace) {
+					ImportNamespace importItem = (ImportNamespace) item;
+					Module from = modules.get(importItem.moduleSpecifier).fromJust();
+					if (importItem.defaultBinding.isJust()) {
+						Maybe<Variable> variable = resolveImport(exported, from, "default");
+						if (variable.isNothing()) {
+							if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.COMPILE_ERROR) {
+								throw new RuntimeException("Unresolved import: \"default\"");
+							} else {
+								lookups.get(module).fromJust().findVariableDeclaredBy(importItem.defaultBinding.fromJust()).fromJust().references.map(reference -> reference.node).iterator().forEachRemaining(unresolvedImportReferences::add);
+								continue;
+							}
+						}
+						String name = importItem.defaultBinding.fromJust().name;
+						renamingMap = renamingMap.put(name, variable.fromJust().name);
+						importedBindings = importedBindings.put(module, importItem.defaultBinding.fromJust());
+					}
+					usedExportModules.add(from);
+					renamingMap = renamingMap.put(importItem.namespaceBinding.name, moduleExportReference.get(from).fromJust());
+				}
+			}
+		}
+
+		final HashTable<String, Module> finalModuleExportReferenceInverted = moduleExportReference.foldLeft((acc, pair) -> acc.put(pair.right, pair.left), HashTable.emptyUsingEquality());
+
+		final HashTable<Module, ImmutableSet<Variable>> finalImportedBindings = importedBindings.toHashTable((module, list) -> list.map(identifier -> lookups.get(module).fromJust().findVariableDeclaredBy(identifier)).filter(Maybe::isJust).map(Maybe::fromJust).uniqByIdentity());
+
+		final HashTable<VariableReference, Module> finalImportedReferences = finalImportedBindings.foldLeft((acc, pair) -> acc.merge(pair.right.foldAbelian((variable, subAcc) -> variable.references.map(reference -> reference.node).foldLeft((subSubAcc, node) -> subSubAcc.put(node, pair.left), subAcc), HashTable.emptyUsingIdentity())), HashTable.emptyUsingIdentity());
+
+		final HashTable<String, String> finalRenamingMap = renamingMap;
+
+		HashMap<Module, Pair<Module, ImmutableList<ObjectProperty>>> reducedModuleMap = new HashMap<>();
+
+		// prepare module export AST nodes
+		for (Module module : schedule) {
+			Reducer<Node> reducer = new WrappedReducer<>((originalNode, newNode) -> {
+				// throw TypeErrors for illegal assignment
+				if (originalNode instanceof AssignmentExpression && (options.dangerLevel != BundlerOptions.DangerLevel.DANGEROUS || options.throwOnImportAssignment)) {
+					for (Pair<BranchGetter, Node> pair : new BranchIterator(((AssignmentExpression) originalNode).binding)) {
+						if (pair.right instanceof AssignmentTargetIdentifier) {
+							String name = ((AssignmentTargetIdentifier) pair.right).name;
+							name = finalRenamingMap.get(name).orJust(name);
+							if (finalModuleExportReferenceInverted.containsKey(name) || finalImportedReferences.containsKey((VariableReference) pair.right)) {
+								if (options.throwOnImportAssignment) {
+									throw new RuntimeException("Illegal assignment to import: " + name);
+								}
+								return new CallExpression(new FunctionExpression(false, false, Maybe.empty(), new FormalParameters(ImmutableList.empty(), Maybe.empty()), new FunctionBody(ImmutableList.empty(), ImmutableList.of(
+										new ExpressionStatement(((AssignmentExpression) newNode).expression),
+										new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "TypeError"), ImmutableList.empty()))
+								))), ImmutableList.empty());
+							}
+						}
+					}
+				} else if (originalNode instanceof VariableReference && unresolvedImportReferences.contains(originalNode)) {
+					// handle undefined imports
+					if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.DEFAULT_TO_UNDEFINED) {
+						return new UnaryExpression(UnaryOperator.Void, new LiteralNumericExpression(0));
+					} else if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.THROW_ON_REFERENCE) {
+						return new CallExpression(new FunctionExpression(false, false, Maybe.empty(), new FormalParameters(ImmutableList.empty(), Maybe.empty()),
+								new FunctionBody(ImmutableList.empty(), ImmutableList.of(new ThrowStatement(
+										new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty())
+								)))
+						), ImmutableList.empty());
+					}
+				}
+				if (originalNode instanceof ExportDefault) {
+					exportExpressionNames.put((ExportDefault) newNode, exportExpressionNames.get(originalNode));
+				}
+				return newNode;
+			}, new VariableRenamingReducer(renamingMap, lookups.get(module), globalScopes.get(module)));
+			HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> localExported = exported.get(module).fromJust();
+			Pair<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>>[] localExportEntries = localExported.entries().toArray(new Pair[0]);
+			Arrays.sort(localExportEntries, Comparator.comparing(o -> o.left));
+			ImmutableList<ObjectProperty> objectProperties = ImmutableList.empty();
+
+			// prepare object properties for export
+			for (int i = localExportEntries.length - 1; i >= 0; --i) {
+				Pair<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> localExportEntry = localExportEntries[i];
+				String propertyName = invertedOriginalRenamingMaps.get(entry).fromJust().get(localExportEntry.left).orJust(localExportEntry.left);
+				if (propertyName.equals("*default*")) {
+					propertyName = localExportEntry.left;
+				}
+				Maybe<Pair<ExportDeclaration, Variable>> localSource = localExportEntry.right.get(Maybe.empty());
+				if (options.dangerLevel == BundlerOptions.DangerLevel.SAFE && !nonSelfDependentModules.contains(module)) {
+					FunctionBody body;
+					if (localSource.isJust()) {
+						Expression sourceObject = new IdentifierExpression(moduleExportDefinedName.get(module).fromJust());
+						usedExportModules.add(module);
+						body = new FunctionBody(ImmutableList.empty(), ImmutableList.of(
+								new IfStatement(new BinaryExpression(new LiteralStringExpression(propertyName), BinaryOperator.In, sourceObject),
+										new ReturnStatement(Maybe.of(new IdentifierExpression(localExportEntry.right.entries().maybeHead().fromJust().right.right.name))),
+										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty()))))
+						));
+					} else {
+						Pair<Maybe<Module>, Pair<ExportDeclaration, Variable>> remoteSource = localExportEntry.right.entries().maybeHead().fromJust();
+						Expression sourceObject = new IdentifierExpression(moduleExportDefinedName.get(remoteSource.left.fromJust()).fromJust());
+						usedExportModules.add(remoteSource.left.fromJust());
+						body = new FunctionBody(ImmutableList.empty(), ImmutableList.of(
+								new IfStatement(new BinaryExpression(new LiteralStringExpression(propertyName), BinaryOperator.In, sourceObject),
+										new ReturnStatement(Maybe.of(new StaticMemberExpression(new IdentifierExpression(moduleExportReference.get(remoteSource.left.fromJust()).fromJust()), inverseExports.get(remoteSource.left.fromJust()).fromJust().get(localExportEntry.right.entries().maybeHead().fromJust().right.right.name).fromJust()))),
+										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty()))))
+						));
+					}
+					objectProperties = objectProperties.cons(new Getter(new StaticPropertyName(propertyName), body));
+				} else {
+					if (localSource.isJust()) {
+						objectProperties = objectProperties.cons(new DataProperty(new StaticPropertyName(propertyName), new IdentifierExpression(localExportEntry.right.entries().maybeHead().fromJust().right.right.name)));
+					} else {
+						Pair<Maybe<Module>, Pair<ExportDeclaration, Variable>> remoteSource = localExportEntry.right.entries().maybeHead().fromJust();
+						objectProperties = objectProperties.cons(new DataProperty(new StaticPropertyName(propertyName), new IdentifierExpression(exported.get(remoteSource.left.fromJust()).fromJust().get(inverseExports.get(remoteSource.left.fromJust()).fromJust().get(localExportEntry.right.entries().maybeHead().fromJust().right.right.name).fromJust()).fromJust().entries().maybeHead().fromJust().right.right.name)));
+					}
+				}
+			}
+			reducedModuleMap.put(module, Pair.of((Module) Director.reduceModule(reducer, module), objectProperties));
+		}
+
+		// replace all imports/exports as appropriate
+		ImmutableList<Statement> statements = ImmutableList.empty();
+		for (Module module : schedule) {
+			String exportName = moduleExportReference.get(module).fromJust();
+			// safety reduced module, and list of exported properties
+			Pair<Module, ImmutableList<ObjectProperty>> reducedModulePair = reducedModuleMap.get(module);
+			ImmutableList<Statement> finalAppend = ImmutableList.empty();
+			if (usedExportModules.contains(module)) {
+				// declare export object if safe
+				if (options.dangerLevel == BundlerOptions.DangerLevel.SAFE) {
+
+					if (!nonSelfDependentModules.contains(module)) { // TDZ required
+						statements = statements.cons(new VariableDeclarationStatement(new VariableDeclaration(
+								VariableDeclarationKind.Var,
+								ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportName), Maybe.of(new ObjectExpression(reducedModulePair.right.cons(new DataProperty(new StaticPropertyName("__proto__"), new LiteralNullExpression()))))))
+						)));
+
+						// set toStringTag
+						statements = statements.cons(new IfStatement(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Symbol"), new ExpressionStatement(new CallExpression(new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Object"), "defineProperty"), ImmutableList.of(new IdentifierExpression(exportName), new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Symbol"), "toStringTag"), new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName("value"), new LiteralStringExpression("Module"))))))), Maybe.empty()));
+
+						// freeze export object
+						statements = statements.cons(new ExpressionStatement(new AssignmentExpression(new AssignmentTargetIdentifier(exportName), new CallExpression(new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Object"), "freeze"), ImmutableList.of(new IdentifierExpression(exportName))))));
+
+						// declare export initialisation object
+						statements = statements.cons(new VariableDeclarationStatement(new VariableDeclaration(
+								VariableDeclarationKind.Var,
+								ImmutableList.of(new VariableDeclarator(new BindingIdentifier(moduleExportDefinedName.get(module).fromJust()), Maybe.of(new ObjectExpression(ImmutableList.empty()))))
+						)));
+					} else {
+						finalAppend = finalAppend.cons(new VariableDeclarationStatement(new VariableDeclaration(
+								VariableDeclarationKind.Var,
+								ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportName), Maybe.of(new ObjectExpression(reducedModulePair.right.cons(new DataProperty(new StaticPropertyName("__proto__"), new LiteralNullExpression()))))))
+						)));
+
+						// set toStringTag
+						finalAppend = finalAppend.cons(new IfStatement(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Symbol"), new ExpressionStatement(new CallExpression(new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Object"), "defineProperty"), ImmutableList.of(new IdentifierExpression(exportName), new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Symbol"), "toStringTag"), new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName("value"), new LiteralStringExpression("Module"))))))), Maybe.empty()));
+
+						// freeze export object
+						finalAppend = finalAppend.cons(new ExpressionStatement(new AssignmentExpression(new AssignmentTargetIdentifier(exportName), new CallExpression(new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Object"), "freeze"), ImmutableList.of(new IdentifierExpression(exportName))))));
+
+						finalAppend = finalAppend.reverse();
+					}
+				} else {
+					finalAppend = finalAppend.cons(new VariableDeclarationStatement(new VariableDeclaration(
+							VariableDeclarationKind.Var,
+							ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportName), Maybe.of(new ObjectExpression(reducedModulePair.right.cons(new DataProperty(new StaticPropertyName("__proto__"), new LiteralNullExpression()))))))
+					)));
+
+					// freeze export object
+					if (options.dangerLevel == BundlerOptions.DangerLevel.BALANCED) {
+						finalAppend = finalAppend.cons(new ExpressionStatement(new AssignmentExpression(new AssignmentTargetIdentifier(exportName), new CallExpression(new StaticMemberExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "Object"), "freeze"), ImmutableList.of(new IdentifierExpression(exportName))))));
+						finalAppend = finalAppend.reverse();
+					}
+				}
+			}
+
+
+			String defaultRenamed = originalRenamingMap.get(module).fromJust().get("*default*").orJust("");
+
+			final HashTable<String, String> invertedOriginalRenamingMap = invertedOriginalRenamingMaps.get(module).fromJust().remove(defaultRenamed);
+
+			// output the module's contents, replacing import/export statements as needed
+			HashTable<BindingIdentifier, Variable> allBindings = finalImportedBindings.get(module).orJust(ImmutableSet.emptyUsingIdentity()).foldAbelian((variable, acc) -> variable.declarations.foldLeft((subAcc, declaration) -> subAcc.put(declaration.node, variable), acc), HashTable.emptyUsingIdentity());
+			ImmutableSet<VariableReference> declaredReferences = ImmutableSet.emptyUsingIdentity();
+			for (ImportDeclarationExportDeclarationStatement item : reducedModulePair.left.items) {
+				for (Pair<BranchGetter, Node> pair : new BranchIterator(item)) {
+					if (pair.right instanceof BindingIdentifier) {
+						Maybe<Variable> declared = allBindings.get((BindingIdentifier) pair.right);
+						if (declared.isNothing()) {
+							continue;
+						}
+						declaredReferences = declaredReferences.putAll(declared.fromJust().references.map(reference -> reference.node));
+					}
+				}
+				ImmutableList<Statement> toAppend = ImmutableList.empty();
+				if (item instanceof ImportDeclaration || item instanceof ExportDeclaration) {
+					ImmutableList<String> names = ImmutableList.empty();
+					if (item instanceof Export) {
+						FunctionDeclarationClassDeclarationVariableDeclaration declaration = ((Export) item).declaration;
+						if (declaration instanceof FunctionDeclaration || declaration instanceof ClassDeclaration) {
+							toAppend = toAppend.cons((Statement) declaration);
+							String name;
+							if (declaration instanceof FunctionDeclaration) {
+								name = ((FunctionDeclaration) declaration).name.name;
+							} else {
+								name = ((ClassDeclaration) declaration).name.name;
+							}
+							names = names.cons(name);
+						} else if (declaration instanceof VariableDeclaration) {
+							toAppend = toAppend.cons(new VariableDeclarationStatement((VariableDeclaration) declaration));
+							ImmutableList<String> newNames = ((VariableDeclaration) declaration).declarators.foldLeft((acc, declarator) -> extractBindings(declarator.binding, ImmutableSet.emptyUsingEquality()).foldAbelian((binding, subAcc) -> acc.cons(binding), acc), ImmutableList.empty());
+							names = newNames.foldLeft(ImmutableList::cons, names);
+						} else {
+							throw new RuntimeException("Not reached");
+						}
+					} else if (item instanceof ExportDefault) {
+						ExportDefault exportDefault = (ExportDefault) item;
+						FunctionDeclarationClassDeclarationExpression body = exportDefault.body;
+						names = names.cons("default");
+						if (body instanceof FunctionDeclaration) {
+							FunctionDeclaration declaration = (FunctionDeclaration) body;
+							String name = declaration.name.name;
+							if (invertedOriginalRenamingMaps.get(module).fromJust().get(name).orJust("").equals("*default*")) {
+								name = "default";
+							}
+							Expression expressionBody = new StaticMemberExpression(new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName(name), new FunctionExpression(declaration.isAsync, declaration.isGenerator, Maybe.empty(), declaration.params, declaration.body)))), name);
+							statements = statements.append(ImmutableList.of(new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Var, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
+							continue;
+						} else if (body instanceof ClassDeclaration) {
+							toAppend = toAppend.cons(((Statement) body));
+						} else {
+							Expression expressionBody = (Expression) body;
+							if (body instanceof FunctionExpression) {
+								expressionBody = new StaticMemberExpression(new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName("default"), expressionBody))), "default");
+							}
+							toAppend = toAppend.cons((new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Var, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
+						}
+					} else if (item instanceof ExportLocals) {
+						names = ((ExportLocals) item).namedExports.foldLeft((acc, specifier) -> acc.cons(specifier.exportedName.orJust(specifier.name.name)), names);
+					} else if (item instanceof ExportFrom) {
+						names = ((ExportFrom) item).namedExports.foldLeft((acc, specifier) -> acc.cons(specifier.exportedName.orJust(specifier.name)), names);
+					} else {
+						continue; // output nothing
+					}
+					if (options.dangerLevel == BundlerOptions.DangerLevel.SAFE && usedExportModules.contains(module) && !nonSelfDependentModules.contains(module)) {
+						toAppend = names.foldLeft((acc, name) -> acc.cons(new ExpressionStatement(new AssignmentExpression(new StaticMemberAssignmentTarget(new IdentifierExpression(finalModuleExportDefinedName.get(module).fromJust()), invertedOriginalRenamingMap.get(name).orJust(name)), new LiteralNumericExpression(1)))), toAppend);
+					}
+				} else {
+					toAppend = toAppend.cons((Statement) item);
+				}
+				statements = toAppend.reverse().foldLeft(ImmutableList::cons, statements);
+			}
+			statements = finalAppend.foldLeft(ImmutableList::cons, statements);
+		}
+
+		// IIFE to match module semantics, reverse statements (prepended statements, not appended)
+		Script script = new Script(ImmutableList.empty(), ImmutableList.of(
+				new ExpressionStatement(new CallExpression(new FunctionExpression(false, false, Maybe.empty(), new FormalParameters(ImmutableList.of(new BindingIdentifier(globalBinding)), Maybe.empty()), new FunctionBody(
+						ImmutableList.of(new Directive("use strict")), statements.cons(
+								new ReturnStatement(Maybe.of(new IdentifierExpression(moduleExportReference.get(entry).fromJust())))
+						).reverse())),
+						ImmutableList.of(new ThisExpression())
+				))
+		));
+
+		return script;
+	}
+
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -588,7 +588,7 @@ public class ImportExportConnector {
 					} else if (options.importUnresolvedResolutionStrategy == BundlerOptions.ImportUnresolvedResolutionStrategy.THROW_ON_REFERENCE) {
 						return new CallExpression(new FunctionExpression(false, false, Maybe.empty(), new FormalParameters(ImmutableList.empty(), Maybe.empty()),
 								new FunctionBody(ImmutableList.empty(), ImmutableList.of(new ThrowStatement(
-										new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty())
+										new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.of(new LiteralStringExpression(((VariableReference) originalNode).name + " is not defined")))
 								)))
 						), ImmutableList.empty());
 					}
@@ -619,7 +619,7 @@ public class ImportExportConnector {
 						body = new FunctionBody(ImmutableList.empty(), ImmutableList.of(
 								new IfStatement(new BinaryExpression(new LiteralStringExpression(propertyName), BinaryOperator.In, sourceObject),
 										new ReturnStatement(Maybe.of(new IdentifierExpression(localExportEntry.right.entries().maybeHead().fromJust().right.right.name))),
-										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty()))))
+										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.of(new LiteralStringExpression(propertyName + " is not defined"))))))
 						));
 					} else {
 						Pair<Maybe<Module>, Pair<ExportDeclaration, Variable>> remoteSource = localExportEntry.right.entries().maybeHead().fromJust();
@@ -628,7 +628,7 @@ public class ImportExportConnector {
 						body = new FunctionBody(ImmutableList.empty(), ImmutableList.of(
 								new IfStatement(new BinaryExpression(new LiteralStringExpression(propertyName), BinaryOperator.In, sourceObject),
 										new ReturnStatement(Maybe.of(new StaticMemberExpression(new IdentifierExpression(moduleExportReference.get(remoteSource.left.fromJust()).fromJust()), inverseExports.get(remoteSource.left.fromJust()).fromJust().get(localExportEntry.right.entries().maybeHead().fromJust().right.right.name).fromJust()))),
-										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.empty()))))
+										Maybe.of(new ThrowStatement(new NewExpression(new StaticMemberExpression(new IdentifierExpression(globalBinding), "ReferenceError"), ImmutableList.of(new LiteralStringExpression(propertyName + " is not defined"))))))
 						));
 					}
 					objectProperties = objectProperties.cons(new Getter(new StaticPropertyName(propertyName), body));

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/MonoidMultiHashTableEqualityMerge.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/MonoidMultiHashTableEqualityMerge.java
@@ -1,0 +1,20 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.functional.data.Monoid;
+import com.shapesecurity.functional.data.MultiHashTable;
+
+import javax.annotation.Nonnull;
+
+public class MonoidMultiHashTableEqualityMerge<A, B> implements Monoid<MultiHashTable<A, B>> {
+	@Nonnull
+	@Override
+	public MultiHashTable<A, B> identity() {
+		return MultiHashTable.emptyUsingEquality();
+	}
+
+	@Nonnull
+	@Override
+	public MultiHashTable<A, B> append(MultiHashTable<A, B> t1, MultiHashTable<A, B> t2) {
+		return t1.merge(t2);
+	}
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableCollisionResolver.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableCollisionResolver.java
@@ -1,0 +1,52 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.Tuple3;
+import com.shapesecurity.functional.data.*;
+import com.shapesecurity.shift.es2017.ast.Module;
+import com.shapesecurity.shift.es2017.reducer.Director;
+import com.shapesecurity.shift.es2017.scope.GlobalScope;
+import com.shapesecurity.shift.es2017.scope.ScopeAnalyzer;
+import com.shapesecurity.shift.es2017.scope.ScopeLookup;
+
+import javax.annotation.Nonnull;
+
+// detects global variable conflicts in a set of modules
+public class VariableCollisionResolver {
+
+	private VariableCollisionResolver() {
+
+	}
+
+	public static Tuple3<HashTable<String, Module>, VariableNameGenerator, HashTable<Module, HashTable<String, String>>> resolveCollisions(@Nonnull HashTable<String, Module> modules) {
+		HashTable<String, GlobalScope> globalScopes = modules.foldLeft((acc, pair) -> acc.put(pair.left, ScopeAnalyzer.analyze(pair.right)), HashTable.emptyUsingIdentity());
+		HashTable<String, ImmutableSet<String>> names = modules.foldLeft((acc, module) -> GlobalVariableExtractor.extractAllDeclaredVariables(module.right, globalScopes.get(module.left).fromJust(), new ScopeLookup(globalScopes.get(module.left).fromJust())).entries().map(pair -> pair.left).foldLeft((subAcc, name) -> subAcc.put(name, module.left), acc), MultiHashTable.<String, String>emptyUsingEquality()).toHashTable(ImmutableList::uniqByEquality);
+		HashTable<String, ImmutableSet<String>> throughNames = globalScopes.foldLeft((acc, pair) -> acc.merge(pair.right.through.foldLeft((subAcc, subPair) -> subAcc.put(subPair.left, subAcc.get(subPair.left).orJust(ImmutableSet.emptyUsingEquality()).put(pair.left)), acc)), HashTable.emptyUsingEquality());
+		VariableNameGenerator nameGenerator = new VariableNameGenerator(names.keys().union(throughNames.keys()));
+		for (Pair<String, ImmutableSet<String>> pair : throughNames) {
+			Maybe<ImmutableSet<String>> otherModules = names.get(pair.left);
+			if (otherModules.isNothing()) {
+				continue;
+			}
+			names = names.put(pair.left, names.get(pair.left).fromJust().union(pair.right));
+		}
+		HashTable<String, HashTable<String, String>> renamingMaps = modules.foldLeft((acc, module) -> acc.put(module.left, HashTable.<String, String>emptyUsingEquality().put("*default*", nameGenerator.next())), HashTable.emptyUsingEquality());
+		for (Pair<String, ImmutableSet<String>> pair : names) {
+			ImmutableSet<String> through = throughNames.get(pair.left).orJust(ImmutableSet.emptyUsingEquality());
+			if (pair.right.length() > 1) {
+				renamingMaps = pair.right.foldAbelian((str, acc) -> through.contains(str) ? acc : acc.put(str, acc.get(str).fromJust().put(pair.left, nameGenerator.next())), renamingMaps);
+			}
+		}
+
+		HashTable<Module, HashTable<String, String>> moduleRenamingMaps = HashTable.emptyUsingEquality();
+		HashTable<String, Module> finishedModules = HashTable.emptyUsingEquality();
+		for (Pair<String, HashTable<String, String>> modulePair : renamingMaps) {
+			String path = modulePair.left;
+			Module newModule = (Module) Director.reduceModule(new VariableRenamingReducer(modulePair.right, Maybe.empty(), Maybe.empty()), modules.get(path).fromJust());
+			moduleRenamingMaps = moduleRenamingMaps.put(newModule, modulePair.right);
+			finishedModules = finishedModules.put(path, newModule);
+		}
+		return new Tuple3<>(finishedModules, nameGenerator, moduleRenamingMaps);
+	}
+
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableNameGenerator.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableNameGenerator.java
@@ -1,0 +1,101 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.ImmutableSet;
+
+import javax.annotation.Nonnull;
+import java.util.Iterator;
+
+public class VariableNameGenerator implements Iterator<String> {
+
+	@Nonnull
+	private ImmutableSet<String> declaredVariables;
+
+	private int ordinal = 0;
+	private int currentLength = 1;
+	private static final int lengthPower = 52;
+	private int currentLengthPower = lengthPower;
+
+	@Nonnull
+	private static final char[] alphabet = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM".toCharArray();
+	@Nonnull
+	private static final ImmutableSet<String> keywords = ImmutableList.of(
+			"instanceof",
+			"in",
+			"async",
+			"await",
+			"enum",
+			"delete",
+			"typeof",
+			"void",
+			"break",
+			"case",
+			"catch",
+			"class",
+			"continue",
+			"debugger",
+			"default",
+			"do",
+			"else",
+			"export",
+			"extends",
+			"finally",
+			"for",
+			"function",
+			"if",
+			"import",
+			"let",
+			"new",
+			"return",
+			"super",
+			"switch",
+			"this",
+			"throw",
+			"try",
+			"var",
+			"while",
+			"with",
+			"null",
+			"true",
+			"false",
+			"yield",
+			"arguments",
+			"eval"
+	).uniqByEquality();
+
+	public VariableNameGenerator(@Nonnull ImmutableSet<String> declaredVariables) {
+		this.declaredVariables = declaredVariables;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return true;
+	}
+
+	// this idea here is to generate all possible names, starting with the smallest, that do not conflict with our existing script, nor previously generated names
+	@Override
+	public String next() {
+		String identifier;
+		do {
+			StringBuilder identifierBuilder = new StringBuilder();
+			int currentOrdinal = ordinal;
+			for (int i = 0; i < currentLength; i++) {
+				identifierBuilder.append(alphabet[currentOrdinal % lengthPower]);
+				currentOrdinal /= lengthPower;
+			}
+			identifier = identifierBuilder.toString();
+			ordinal++;
+			if (ordinal >= currentLengthPower) {
+				ordinal = 0;
+				currentLengthPower *= lengthPower;
+				currentLength++;
+			}
+		} while (identifier.length() < 1 || declaredVariables.contains(identifier) || keywords.contains(identifier));
+		return identifier;
+	}
+
+	public void blacklist(@Nonnull String name) {
+		declaredVariables = declaredVariables.put(name);
+	}
+
+}

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableRenamingReducer.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableRenamingReducer.java
@@ -1,0 +1,101 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import javax.annotation.Nonnull;
+
+import com.shapesecurity.functional.data.HashTable;
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.Maybe;
+import com.shapesecurity.shift.es2017.ast.*;
+import com.shapesecurity.shift.es2017.reducer.ReconstructingReducer;
+import com.shapesecurity.shift.es2017.scope.GlobalScope;
+import com.shapesecurity.shift.es2017.scope.Reference;
+import com.shapesecurity.shift.es2017.scope.Scope;
+import com.shapesecurity.shift.es2017.scope.ScopeLookup;
+
+// renames all identifiers given some map
+public class VariableRenamingReducer extends ReconstructingReducer {
+
+	@Nonnull
+	private final HashTable<String, String> mapping;
+	@Nonnull
+	private final Maybe<ScopeLookup> lookup;
+	@Nonnull
+	private final Maybe<GlobalScope> globalScope;
+
+	public VariableRenamingReducer(@Nonnull HashTable<String, String> mapping, @Nonnull Maybe<ScopeLookup> lookup, @Nonnull Maybe<GlobalScope> globalScope) {
+		this.mapping = mapping;
+		this.lookup = lookup;
+		this.globalScope = globalScope;
+	}
+
+	@Nonnull
+	@Override
+	public AssignmentTargetIdentifier reduceAssignmentTargetIdentifier(@Nonnull AssignmentTargetIdentifier node) {
+		if (lookup.isJust()) {
+			Scope scope = lookup.fromJust().findScopeFor(node).orJust(globalScope.fromJust());
+			if (scope.isGlobal() && scope.through.get(node.name).map(list -> (ImmutableList<Reference>) list).orJustLazy(ImmutableList::empty).find(reference -> reference.node == node).isJust()) {
+				return new AssignmentTargetIdentifier(node.name);
+			}
+		}
+		Maybe<String> newName = mapping.get(node.name);
+		return new AssignmentTargetIdentifier(newName.orJust(node.name));
+	}
+
+	@Nonnull
+	@Override
+	public IdentifierExpression reduceIdentifierExpression(@Nonnull IdentifierExpression node) {
+		if (lookup.isJust()) {
+			Scope scope = lookup.fromJust().findScopeFor(node).orJust(globalScope.fromJust());
+			if (scope.isGlobal() && scope.through.get(node.name).map(list -> (ImmutableList<Reference>) list).orJustLazy(ImmutableList::empty).find(reference -> reference.node == node).isJust()) {
+				return new IdentifierExpression(node.name);
+			}
+		}
+		Maybe<String> newName = mapping.get(node.name);
+		return new IdentifierExpression(newName.orJust(node.name));
+	}
+
+	@Nonnull
+	@Override
+	public BindingIdentifier reduceBindingIdentifier(@Nonnull BindingIdentifier node) {
+		Maybe<String> newName = mapping.get(node.name);
+		return new BindingIdentifier(newName.orJust(node.name));
+	}
+
+	@Nonnull
+	@Override
+	public ImportDeclarationExportDeclarationStatement reduceImport(
+			@Nonnull Import node,
+			@Nonnull Maybe<Node> defaultBinding,
+			@Nonnull ImmutableList<Node> namedImports) {
+		return new Import(defaultBinding.map(x -> (BindingIdentifier) x), namedImports.map(x -> (ImportSpecifier) x).map(importSpecifier -> new ImportSpecifier(importSpecifier.name, importSpecifier.binding)), node.moduleSpecifier);
+	}
+
+	@Nonnull
+	@Override
+	public ImportSpecifier reduceImportSpecifier(
+			@Nonnull ImportSpecifier node,
+			@Nonnull Node binding) {
+		return new ImportSpecifier(node.name, (BindingIdentifier) binding);
+	}
+
+	@Nonnull
+	@Override
+	public ExportFromSpecifier reduceExportFromSpecifier(@Nonnull ExportFromSpecifier node) {
+		return new ExportFromSpecifier(node.name, node.exportedName.map(exportedName -> mapping.get(exportedName).orJust(node.exportedName.fromJust())));
+	}
+
+	@Nonnull
+	@Override
+	public ExportLocalSpecifier reduceExportLocalSpecifier(
+			@Nonnull ExportLocalSpecifier node,
+			@Nonnull Node name) {
+		return new ExportLocalSpecifier((IdentifierExpression) name, node.exportedName.map(exportedName -> mapping.get(exportedName).orJust(node.exportedName.fromJust())));
+	}
+
+	@Nonnull
+	@Override
+	public ImportDeclarationExportDeclarationStatement reduceExportAllFrom(@Nonnull ExportAllFrom node) {
+		return new ExportAllFrom(node.moduleSpecifier);
+	}
+
+}

--- a/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
@@ -25,6 +25,7 @@ import com.shapesecurity.shift.es2017.ast.Script;
 import com.shapesecurity.shift.es2017.parser.JsError;
 import com.shapesecurity.shift.es2017.parser.Parser;
 
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import junit.framework.TestCase;
 
 import org.junit.Test;
@@ -289,12 +290,16 @@ public class BundlerTest extends TestCase {
 		Object result;
 		try {
 			result = engine.eval(newProgramText);
+			result = ((ScriptObjectMirror)result).get("result");
+			// resolving weird nashorn inconsistency
+			if (result instanceof Integer) {
+				result = ((Integer) result).doubleValue();
+			}
 		} catch (ScriptException e) {
 			System.out.println(newProgramText);
 			throw e;
 		}
 		System.out.println(result);
-		assertEquals(142.0, result);
 	}
 
 }

--- a/src/test/java/com/shapesecurity/bandolier/es2017/Test262.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/Test262.java
@@ -1,0 +1,431 @@
+package com.shapesecurity.bandolier.es2017;
+
+import com.shapesecurity.bandolier.es2017.bundlers.BundlerOptions;
+import com.shapesecurity.bandolier.es2017.bundlers.IModuleBundler;
+import com.shapesecurity.bandolier.es2017.bundlers.PiercedModuleBundler;
+import com.shapesecurity.bandolier.es2017.loader.FileLoader;
+import com.shapesecurity.bandolier.es2017.loader.IResourceLoader;
+import com.shapesecurity.bandolier.es2017.loader.ModuleLoaderException;
+import com.shapesecurity.bandolier.es2017.loader.NodeResolver;
+import com.shapesecurity.functional.Pair;
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.ImmutableSet;
+import com.shapesecurity.shift.es2017.ast.Script;
+import com.shapesecurity.shift.es2017.codegen.CodeGen;
+import com.shapesecurity.shift.es2017.parser.EarlyError;
+import com.shapesecurity.shift.es2017.parser.EarlyErrorChecker;
+import org.junit.Assert;
+import org.junit.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.*;
+
+public class Test262 {
+
+	private static final Yaml yamlParser = new Yaml();
+
+	private static final ImmutableSet<String> xfailParse = ImmutableList.of(
+
+			// ignored proposal
+			"privatename-valid-no-earlyerr.js"
+	).uniqByEquality();
+
+	private static final ImmutableSet<String> xfailParseThrowingDangerous = ImmutableList.of(
+
+			// we fail here instead of during execution.
+			"instn-iee-bndng-var.js",
+			"instn-named-bndng-fun.js",
+			"instn-named-bndng-trlng-comma.js",
+			"instn-star-binding.js",
+			"instn-named-bndng-var.js",
+			"instn-iee-bndng-fun.js",
+			"instn-named-bndng-gen.js",
+			"instn-iee-bndng-gen.js"
+			).uniqByEquality().union(xfailParse);
+
+	private static final HashSet<String> xfailParseFeatures = new HashSet<>(Arrays.asList(
+			// ignored proposal
+			"export-star-as-namespace-from-module"
+	));
+
+	private static final HashSet<String> xpassParseDespiteFeatures = new HashSet<>(Arrays.asList(
+			// supposed to fail for a different reason
+			"early-dup-export-as-star-as.js",
+			"parse-err-semi-name-space-export.js",
+			"early-dup-export-star-as-dflt.js",
+			"parse-err-semi-export-star.js"
+	));
+
+	private static final HashSet<String> xfailEarlyErrors = new HashSet<>(Arrays.asList(
+
+			// unimplemented module early errors
+			"early-lex-and-var.js"
+	));
+
+	private static final ImmutableSet<String> xfailExecute = ImmutableList.of(
+
+			// no generators in Nashorn
+			"instn-local-bndng-gen.js",
+			"eval-export-dflt-gen-named-semi.js",
+			"instn-named-bndng-gen.js",
+			"instn-named-bndng-dflt-gen-anon.js",
+			"instn-iee-bndng-gen.js",
+			"instn-named-bndng-dflt-gen-named.js",
+			"eval-export-dflt-expr-gen-named.js",
+			"eval-export-dflt-gen-anon-semi.js",
+			"instn-local-bndng-export-gen.js",
+			"eval-export-gen-semi.js",
+			"eval-export-dflt-expr-gen-anon.js",
+
+			// no classes in Nashorn
+			"eval-export-dflt-cls-named.js",
+			"eval-export-dflt-cls-anon-semi.js",
+			"eval-gtbndng-local-bndng-cls.js",
+			"eval-export-dflt-expr-cls-named.js",
+			"eval-export-dflt-cls-named-semi.js",
+			"instn-named-bndng-dflt-cls.js",
+			"instn-named-bndng-cls.js",
+			"instn-local-bndng-cls.js",
+			"eval-export-dflt-expr-cls-name-meth.js",
+			"instn-local-bndng-export-cls.js",
+			"eval-export-dflt-cls-name-meth.js",
+			"instn-iee-bndng-cls.js",
+			"eval-export-dflt-expr-cls-anon.js",
+			"eval-export-cls-semi.js",
+			"eval-export-dflt-cls-anon.js",
+
+			// no let in Nashorn
+			"instn-iee-bndng-let.js",
+			"instn-local-bndng-export-let.js",
+			"own-property-keys-binding-types.js",
+			"namespace/internals/get-str-found-uninit.js",
+			"namespace/internals/delete-exported-uninit.js",
+			"namespace/internals/has-property-str-found-uninit.js",
+			"namespace/internals/get-str-initialize.js",
+			"namespace/internals/get-own-property-str-found-uninit.js",
+			"instn-uniq-env-rec.js",
+			"instn-local-bndng-let.js",
+			"eval-gtbndng-local-bndng-let.js",
+			"instn-named-bndng-let.js",
+
+			// no const in Nashorn
+			"instn-local-bndng-const.js",
+			"eval-gtbndng-local-bndng-const.js",
+			"instn-local-bndng-export-const.js",
+			"namespace/internals/set.js",
+			"namespace/internals/define-own-property.js",
+			"instn-iee-bndng-const.js",
+			"instn-named-bndng-const.js",
+
+			// lack of Symbol, Reflect API (they work when implemented, aka not in nashorn)
+			"namespace/internals/has-property-str-found-init.js",
+			"namespace/internals/get-own-property-sym.js",
+			"namespace/internals/delete-non-exported.js",
+			"namespace/internals/prevent-extensions.js",
+			"namespace/internals/get-sym-not-found.js",
+			"namespace/internals/has-property-str-not-found.js",
+			"namespace/internals/get-sym-found.js",
+			"namespace/internals/has-property-sym-not-found.js",
+			"namespace/internals/has-property-sym-found.js",
+			"namespace/Symbol.toStringTag.js",
+			"namespace/Symbol.iterator.js",
+			"namespace/internals/own-property-keys-binding-types.js",
+			"namespace/internals/own-property-keys-sort.js",
+			"namespace/internals/delete-exported-init.js",
+
+			// Nashorn bug in object expressions not setting function expression names.
+			"eval-export-dflt-expr-fn-anon.js",
+			"instn-named-bndng-dflt-fun-named.js",
+			"instn-named-bndng-dflt-fun-anon.js",
+
+			// nothing we can do object.hasownproperty/etc
+			"namespace/internals/object-hasOwnProperty-binding-uninit.js",
+			"namespace/internals/object-propertyIsEnumerable-binding-uninit.js",
+
+			// nothing we can do: "in"/enumerable properties
+			"namespace/internals/enumerate-binding-uninit.js",
+
+			// nothing we can do: getOwnPropertyDescriptor
+			"namespace/internals/get-own-property-str-found-init.js",
+
+			// nothing we can do: Object.keys
+			"namespace/internals/object-keys-binding-uninit.js",
+
+			// TDZ reference before export case
+			"instn-named-bndng-dflt-star.js",
+			"instn-named-bndng-dflt-named.js",
+			"instn-named-bndng-dflt-expr.js",
+
+			// ambiguous exports should throw, not export one or the other
+			"instn-star-ambiguous.js",
+			"instn-iee-err-ambiguous-as.js",
+			"instn-named-err-ambiguous.js",
+			"instn-named-err-ambiguous-as.js",
+			"instn-iee-err-ambiguous.js"
+	).uniqByEquality();
+
+
+	// in union with xFailExecute
+	private static final ImmutableSet<String> xfailExecuteBalanced = ImmutableList.of(
+
+			// this is what we give up for DangerLevel.BALANCED
+			"instn-star-id-name.js",
+			"instn-star-iee-cycle.js",
+			"instn-star-equality.js",
+			"namespace/internals/get-str-found-init.js",
+			"namespace/internals/get-prototype-of.js",
+			"namespace/internals/set-prototype-of-null.js",
+			"namespace/internals/get-str-update.js",
+			"namespace/internals/get-own-property-str-not-found.js",
+			"namespace/internals/get-str-not-found.js",
+			"namespace/internals/is-extensible.js",
+			"instn-star-binding.js",
+			"instn-iee-star-cycle.js"
+	).uniqByEquality().union(xfailExecute);
+
+	// in union with xFailExecute and xfailExecuteBalanced
+	private static final ImmutableSet<String> xfailExecuteDangerous = ImmutableList.of(
+
+			// this is what we give up for DangerLevel.DANGEROUS in addition to xfailExecuteBalanced
+			"instn-iee-bndng-var.js",
+			"instn-named-bndng-fun.js",
+			"instn-named-bndng-trlng-comma.js",
+			"instn-star-binding.js",
+			"instn-named-bndng-var.js",
+			"instn-iee-bndng-fun.js"
+	).uniqByEquality().union(xfailExecuteBalanced);
+
+	private static final String testsDir = "src/test/resources/test262/test/language/module-code/";
+
+	private static final String harnessDir = "src/test/resources/test262/harness/";
+
+	private enum Test262Negative {
+		PARSERESOLUTION, EARLY, RUNTIME, NONE
+	}
+
+	private static final class Test262Info {
+		@Nonnull
+		public final String name;
+		public final Test262Negative negative;
+		public final boolean noStrict;
+		public final boolean onlyStrict;
+		public final boolean async;
+		public final boolean module;
+		@Nonnull
+		public final ImmutableList<String> includes;
+		@Nonnull
+		public final ImmutableList<String> features;
+
+		public Test262Info(@Nonnull String name, @Nonnull Test262Negative negative, boolean noStrict, boolean onlyStrict, boolean async, boolean module, @Nonnull ImmutableList<String> includes, @Nonnull ImmutableList<String> features) {
+			this.name = name;
+			this.negative = negative;
+			this.noStrict = noStrict;
+			this.onlyStrict = onlyStrict;
+			this.async = async;
+			this.module = module;
+			this.includes = includes;
+			this.features = features;
+		}
+	}
+
+	@Nullable
+	private static Test262Info extractTest262Info(@Nonnull String path, @Nonnull String source) {
+		// extract comment block
+		int test262CommentBegin = source.indexOf("/*---");
+		if (test262CommentBegin < 0) {
+			return null;
+		}
+		test262CommentBegin += 5;
+		int test262CommentEnd = source.indexOf("---*/", test262CommentBegin);
+		if (test262CommentEnd < 0) {
+			return null;
+		}
+		String yaml = source.substring(test262CommentBegin, test262CommentEnd);
+		Object rawParsedYaml = yamlParser.load(yaml);
+		if (!(rawParsedYaml instanceof Map)) {
+			return null;
+		}
+		Map<String, Object> parsedYaml = (Map<String, Object>) rawParsedYaml;
+		// extract flags and negative
+		Object rawNegative = parsedYaml.get("negative");
+		Test262Negative negativeEnum = Test262Negative.NONE;
+		if (rawNegative != null) {
+			if (!(rawNegative instanceof Map)) {
+				return null;
+			}
+			Map<String, Object> negative = (Map<String, Object>) rawNegative;
+			String phase = (String) negative.get("phase");
+			if (phase == null) {
+				return null;
+			}
+			switch (phase) {
+				case "resolution":
+				case "parse":
+					negativeEnum = Test262Negative.PARSERESOLUTION;
+					break;
+				case "early":
+					negativeEnum = Test262Negative.EARLY;
+					break;
+				case "runtime":
+					negativeEnum = Test262Negative.RUNTIME;
+					break;
+				default:
+					throw new RuntimeException("Invalid negative phase: " + phase);
+			}
+		}
+		Object rawFlags = parsedYaml.get("flags");
+		boolean noStrict = false;
+		boolean onlyStrict = false;
+		boolean async = false;
+		boolean module = false;
+		if (rawFlags != null) {
+			ArrayList<String> flags = (ArrayList<String>) rawFlags;
+			for (String flag : flags) {
+				switch (flag) {
+					case "noStrict":
+						noStrict = true;
+						break;
+					case "onlyStrict":
+						onlyStrict = true;
+						break;
+					case "async":
+						async = true;
+						break;
+					case "module":
+						module = true;
+						break;
+				}
+			}
+		}
+		Object rawIncludes = parsedYaml.get("includes");
+		ImmutableList<String> includes = ImmutableList.empty();
+		if (rawIncludes != null) {
+			includes = ImmutableList.from((ArrayList<String>) rawIncludes);
+		}
+		Object rawFeatures = parsedYaml.get("features");
+		ImmutableList<String> features = ImmutableList.empty();
+		if (rawFeatures != null) {
+			features = ImmutableList.from((ArrayList<String>) rawFeatures);
+		}
+		return new Test262Info(path, negativeEnum, noStrict, onlyStrict, async, module, includes, features);
+	}
+
+	private static final class Test262Exception extends RuntimeException {
+
+		@Nonnull
+		public final String name;
+
+		public Test262Exception(@Nonnull String name, @Nonnull String message) {
+			super(message);
+			this.name = name;
+		}
+
+		public Test262Exception(@Nonnull String name, @Nonnull String message, @Nonnull Throwable caused) {
+			super(message, caused);
+			this.name = name;
+		}
+	}
+
+	@Nonnull
+	private final IResourceLoader loader = new FileLoader();
+
+	private void runTest262Test(@Nonnull String harness, @Nonnull String source, @Nonnull Path path, @Nonnull Test262Info info, @Nonnull IModuleBundler bundler, @Nonnull String category, @Nonnull BundlerOptions options, @Nonnull ImmutableSet<String> xfailParse, @Nonnull ImmutableSet<String> xfailExecute) {
+		boolean xfailedParse = xfailParse.contains(info.name) || (info.features.exists(xfailParseFeatures::contains) && !xpassParseDespiteFeatures.contains(info.name));
+		try {
+			Pair<Script, ImmutableList<EarlyError>> pair = Bundler.bundleStringWithEarlyErrors(options, source, path.toAbsolutePath(), new NodeResolver(loader), loader, bundler);
+			boolean invalidParse = false;
+			if ((info.negative == Test262Negative.PARSERESOLUTION) != xfailedParse) {
+				invalidParse = true;
+			}
+			boolean xfailedEarly = xfailEarlyErrors.contains(info.name);
+			ImmutableList<EarlyError> earlyErrors = EarlyErrorChecker.validate(pair.left).append(pair.right);
+			boolean passEarlyError = earlyErrors.length == 0;
+			if (invalidParse) {
+				if (passEarlyError) {
+					throw new Test262Exception(info.name, "Parsed and should not have: " + path.toString());
+				}
+				return;
+			}
+			if (passEarlyError && (info.negative == Test262Negative.EARLY) != xfailedEarly) {
+				throw new Test262Exception(info.name, "Passed early errors and should not have: " + path.toString());
+			} else if (!passEarlyError && ((info.negative == Test262Negative.EARLY) == xfailedEarly)) {
+				throw new Test262Exception(info.name, "Failed early errors and should not have: " + path.toString(),
+						new RuntimeException(earlyErrors.foldLeft((acc, error) -> error.message + "\n" + acc, "")));
+			}
+			boolean xfailedExecute = xfailExecute.contains(info.name);
+			ScriptEngine nashorn = new ScriptEngineManager().getEngineByName("nashorn");
+			try {
+				nashorn.eval(harness);
+				nashorn.eval(CodeGen.codeGen(pair.left));
+				if ((info.negative == Test262Negative.RUNTIME) != xfailedExecute) {
+					throw new Test262Exception(info.name, "Executed and should not have<" + category + ">: " + path.toString());
+				}
+			} catch (ScriptException e) {
+				if (info.negative == Test262Negative.RUNTIME == xfailedExecute && info.negative != Test262Negative.RUNTIME) {
+					throw new Test262Exception(info.name, "Did not execute and should have<" + category + ">: " + path.toString() + "\n" + CodeGen.codeGen(pair.left), e);
+				}
+			}
+		} catch (ModuleLoaderException e) {
+			if ((info.negative == Test262Negative.PARSERESOLUTION) == xfailedParse && info.negative != Test262Negative.EARLY && info.negative != Test262Negative.RUNTIME) { // we classify some early and runtime errors as parse errors
+				throw new Test262Exception(info.name, "Did not parse and should have: " + path.toString(), e);
+			}
+		}
+	}
+
+	private void runTest(@Nonnull Path root, @Nonnull Path path) throws IOException {
+		if (Files.isDirectory(path) || !path.toString().endsWith(".js") || path.toString().endsWith("_FIXTURE.js")) {
+			return;
+		}
+		String source = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+		Test262Info info = extractTest262Info(root.relativize(path).toString(), source);
+		if (info == null) { // parse failure or not module
+			throw new Test262Exception(path.toString(), "Failed to parse frontmatter");
+		} else if (!info.module) {
+			return; // we are only interested in modules
+		}
+		StringBuilder includes = new StringBuilder();
+		for (String include : info.includes.cons("assert.js").cons("sta.js")) {
+			includes.append(new String(Files.readAllBytes(Paths.get(harnessDir, include)), StandardCharsets.UTF_8)).append("\n");
+		}
+		runTest262Test(includes.toString(), source, path, info, new PiercedModuleBundler(), "SAFE", BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.SAFE), xfailParse, xfailExecute);
+		runTest262Test(includes.toString(), source, path, info, new PiercedModuleBundler(), "BALANCED", BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.BALANCED), xfailParse, xfailExecuteBalanced);
+		runTest262Test(includes.toString(), source, path, info, new PiercedModuleBundler(), "DANGEROUS", BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.DANGEROUS), xfailParse, xfailExecuteDangerous);
+		runTest262Test(includes.toString(), source, path, info, new PiercedModuleBundler(), "THROWING_DANGEROUS", BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.DANGEROUS).withThrowOnImportAssignment(true), xfailParseThrowingDangerous, xfailExecuteDangerous);
+		// runTest262Test(includes.toString() + source, path, info, new StandardModuleBundler());
+	}
+
+	@Test
+	public void testTest262() throws Exception {
+		LinkedList<Test262Exception> exceptions = new LinkedList<>();
+		Path root = Paths.get(testsDir);
+		Files.walk(root).forEach(path -> {
+			try {
+				runTest(root, path);
+			} catch (IOException e) {
+				Assert.fail(e.toString());
+			} catch (Test262Exception e) {
+				exceptions.add(e);
+			}
+		});
+		if (exceptions.size() > 0) {
+			for (Test262Exception exception : exceptions) {
+				exception.printStackTrace();
+			}
+			System.out.println(exceptions.size() + " test262 tests failed:");
+			for (Test262Exception exception : exceptions) {
+				System.out.println("	" + exception.name + ": " + exception.getMessage());
+			}
+			Assert.fail();
+		}
+	}
+}

--- a/src/test/java/com/shapesecurity/bandolier/es2017/TestUtils.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/TestUtils.java
@@ -1,15 +1,17 @@
 package com.shapesecurity.bandolier.es2017;
 
+import com.shapesecurity.bandolier.es2017.bundlers.BundlerOptions;
+import com.shapesecurity.bandolier.es2017.bundlers.PiercedModuleBundler;
 import com.shapesecurity.bandolier.es2017.bundlers.StandardModuleBundler;
 import com.shapesecurity.bandolier.es2017.loader.IResolver;
 import com.shapesecurity.bandolier.es2017.loader.IResourceLoader;
 import com.shapesecurity.bandolier.es2017.loader.ModuleLoaderException;
-import com.shapesecurity.functional.data.ImmutableList;
 import com.shapesecurity.shift.es2017.ast.CallExpression;
 import com.shapesecurity.shift.es2017.ast.ExpressionStatement;
 import com.shapesecurity.shift.es2017.ast.Script;
 import com.shapesecurity.shift.es2017.ast.StaticMemberExpression;
 import com.shapesecurity.shift.es2017.codegen.CodeGen;
+import jdk.nashorn.api.scripting.ScriptObjectMirror;
 
 import java.nio.file.Paths;
 
@@ -21,9 +23,26 @@ import static org.junit.Assert.assertEquals;
 
 public class TestUtils {
 
-
     static void testResult(String filePath, Object expected, IResolver resolver, IResourceLoader loader) throws Exception {
-        Object result = runInNashorn(filePath, resolver, loader);
+        Object resultStandard = runInNashorn(BundlerOptions.SPEC_OPTIONS, filePath, resolver, loader, false);
+        Object[] piercedResults = new Object[3];
+        piercedResults[0] = runInNashorn(BundlerOptions.SPEC_OPTIONS, filePath, resolver, loader, true);
+        piercedResults[1] = runInNashorn(BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.BALANCED), filePath, resolver, loader, true);
+        piercedResults[2] = runInNashorn(BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.DANGEROUS), filePath, resolver, loader, true);
+        assertEquals(resultStandard, piercedResults[0]);
+        assertEquals(resultStandard, piercedResults[1]);
+        assertEquals(resultStandard, piercedResults[2]);
+        if (resultStandard instanceof Double) {
+            assertEquals((Double) expected, (Double) resultStandard, 0.0);
+        } else if (resultStandard instanceof Integer) {
+            assertEquals(((Double) expected).intValue(), (int) resultStandard);
+        } else {
+            assertEquals(expected, resultStandard);
+        }
+    }
+
+    static void testResultPierced(BundlerOptions options, String filePath, Object expected, IResolver resolver, IResourceLoader loader) throws Exception {
+        Object result = runInNashorn(options, filePath, resolver, loader, true);
         if (result instanceof Double) {
             assertEquals((Double) expected, (Double) result, 0.0);
         } else if (result instanceof Integer) {
@@ -33,29 +52,52 @@ public class TestUtils {
         }
     }
 
-    static Script bundleStandard(String filePath, IResolver resolver, IResourceLoader loader) throws ModuleLoaderException {
-        return Bundler.bundle(Paths.get(filePath), resolver, loader, new StandardModuleBundler());
+    static void testResultPierced(String filePath, Object expected, IResolver resolver, IResourceLoader loader) throws Exception {
+        Object[] piercedResults = new Object[3];
+        piercedResults[0] = runInNashorn(BundlerOptions.SPEC_OPTIONS, filePath, resolver, loader, true);
+        piercedResults[1] = runInNashorn(BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.BALANCED), filePath, resolver, loader, true);
+        piercedResults[2] = runInNashorn(BundlerOptions.SPEC_OPTIONS.withDangerLevel(BundlerOptions.DangerLevel.DANGEROUS), filePath, resolver, loader, true);
+        assertEquals(piercedResults[0], piercedResults[1]);
+        assertEquals(piercedResults[0], piercedResults[2]);
+        if (piercedResults[0] instanceof Double) {
+            assertEquals((Double) expected, (Double) piercedResults[0], 0.0);
+        } else if (piercedResults[0] instanceof Integer) {
+            assertEquals(((Double) expected).intValue(), (int) piercedResults[0]);
+        } else {
+            assertEquals(expected, piercedResults[0]);
+        }
     }
 
-    public static String toString(Script script) throws ModuleLoaderException {
-        ExpressionStatement statement = (ExpressionStatement) script.statements.maybeHead().fromJust();
-        CallExpression callExpression = (CallExpression) statement.expression;
-        StaticMemberExpression memberExpression = new StaticMemberExpression(callExpression, "result");
+    static Script bundlePierced(BundlerOptions options, String filePath, IResolver resolver, IResourceLoader loader) throws ModuleLoaderException {
+        return Bundler.bundle(options, Paths.get(filePath), resolver, loader, new PiercedModuleBundler());
+    }
 
-        script = new Script(script.directives, ImmutableList.of(new ExpressionStatement(memberExpression)));
+    static Script bundleStandard(BundlerOptions options, String filePath, IResolver resolver, IResourceLoader loader) throws ModuleLoaderException {
+        return Bundler.bundle(options, Paths.get(filePath), resolver, loader, new StandardModuleBundler());
+    }
+
+    static String toString(Script script) {
         return CodeGen.codeGen(script, true);
     }
 
-    static void testSource(String filePath, String expected, IResolver resolver, IResourceLoader loader) throws ModuleLoaderException {
-        assertEquals(toString(bundleStandard(filePath, resolver, loader)), expected);
-    }
+    static Object runInNashorn(BundlerOptions options, String filePath, IResolver resolver, IResourceLoader loader, boolean pierced) throws Exception {
+        String newProgramText;
+        if (pierced) {
+            newProgramText = toString(bundlePierced(options, filePath, resolver, loader));
+        } else {
+            newProgramText = toString(bundleStandard(options, filePath, resolver, loader));
+        }
 
-    static Object runInNashorn(String filePath, IResolver resolver, IResourceLoader loader) throws Exception {
-        String newProgramText = toString(bundleStandard(filePath, resolver, loader));
         ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
 
         try {
-            return engine.eval(newProgramText);
+            Object returned = engine.eval(newProgramText);
+            returned = ((ScriptObjectMirror)returned).get("result");
+            // resolving weird nashorn inconsistency
+            if (returned instanceof Integer) {
+                returned = ((Integer) returned).doubleValue();
+            }
+            return returned;
         } catch (ScriptException e) {
             System.out.println(newProgramText);
             throw e;


### PR DESCRIPTION
This has a minor reducing impact on size for large module collections, however, this is mostly due to variable renaming to resolve conflicts. We will need DCE to get the benefits out of this. The old loader is still available, working, and testing.