### PR TITLE
Fix prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "mvn assembly:assembly -DdescriptorId=jar-with-dependencies",
-    "prepublish": "npm run build && cp -v target/es2017-*-jar-with-dependencies.jar bin/bandolier.jar"
+    "prepublish": "cp -v target/es2017-*-jar-with-dependencies.jar bin/bandolier.jar"
   },
   "bin": "bin/bandolier.sh",
   "repository": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
 


### PR DESCRIPTION
`npm run build` is redundant.

Contains version bump, rebase not merge.