### PR TITLE
Add empty .npmignore, v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -18,5 +18,6 @@
   "bugs": {
     "url": "https://github.com/shapesecurity/bandolier/issues"
   },
-  "homepage": "https://github.com/shapesecurity/bandolier#readme"
+  "homepage": "https://github.com/shapesecurity/bandolier#readme",
+  "files": ["index.js", "bin"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.1.0</version>
+    <version>3.1.1</version>
     <packaging>jar</packaging>
 
 


### PR DESCRIPTION
Fixes junk in npm releases, missing jar file.

`$ npm pack --dry-run`:
```
741B   package.json     
11.4kB LICENSE          
2.3kB  README.md        
4.0MB  bin/bandolier.jar
446B   bin/bandolier.sh 
```