### PR TITLE
Fix name collision with generated module names and function local assignments, version 3.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.2.2</version>
+    <version>3.2.3</version>
     <packaging>jar</packaging>
 
 

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -320,7 +320,7 @@ public class ImportExportConnector {
 		// perform initial export extraction and prepare for proxy export resolution
 		for (Pair<String, Module> pair : modules) {
 			ScopeLookup lookup = lookups.get(pair.right).fromJust();
-			HashTable<String, String> exportNames = invertedOriginalRenamingMaps.get(pair.right).fromJust();//
+			HashTable<String, String> exportNames = invertedOriginalRenamingMaps.get(pair.right).fromJust();
 			HashTable<String, HashTable<Maybe<Module>, Pair<ExportDeclaration, Variable>>> localExported = exported.get(pair.right).orJust(HashTable.emptyUsingEquality());
 
 			for (ImportDeclarationExportDeclarationStatement item : pair.right.items) {

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableCollisionResolver.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableCollisionResolver.java
@@ -20,18 +20,19 @@ public class VariableCollisionResolver {
 
 	public static Tuple3<HashTable<String, Module>, VariableNameGenerator, HashTable<Module, HashTable<String, String>>> resolveCollisions(@Nonnull HashTable<String, Module> modules) {
 		HashTable<String, GlobalScope> globalScopes = modules.foldLeft((acc, pair) -> acc.put(pair.left, ScopeAnalyzer.analyze(pair.right)), HashTable.emptyUsingIdentity());
-		HashTable<String, ImmutableSet<String>> names = modules.foldLeft((acc, module) -> GlobalVariableExtractor.extractAllDeclaredVariables(module.right, globalScopes.get(module.left).fromJust(), new ScopeLookup(globalScopes.get(module.left).fromJust())).entries().map(pair -> pair.left).foldLeft((subAcc, name) -> subAcc.put(name, module.left), acc), MultiHashTable.<String, String>emptyUsingEquality()).toHashTable(ImmutableList::uniqByEquality);
+		HashTable<String, ImmutableSet<String>> globalNames = modules.foldLeft((acc, module) -> GlobalVariableExtractor.extractAllDeclaredVariables(module.right, globalScopes.get(module.left).fromJust(), new ScopeLookup(globalScopes.get(module.left).fromJust())).entries().map(pair -> pair.left).foldLeft((subAcc, name) -> subAcc.put(name, module.left), acc), MultiHashTable.<String, String>emptyUsingEquality()).toHashTable(ImmutableList::uniqByEquality);
+		ImmutableSet<String> allNames = modules.foldLeft((acc, module) -> acc.union(VariableReferenceExtractor.extractAllReferencedVariableNames(globalScopes.get(module.left).fromJust())), ImmutableSet.emptyUsingEquality());
 		HashTable<String, ImmutableSet<String>> throughNames = globalScopes.foldLeft((acc, pair) -> acc.merge(pair.right.through.foldLeft((subAcc, subPair) -> subAcc.put(subPair.left, subAcc.get(subPair.left).orJust(ImmutableSet.emptyUsingEquality()).put(pair.left)), acc)), HashTable.emptyUsingEquality());
-		VariableNameGenerator nameGenerator = new VariableNameGenerator(names.keys().union(throughNames.keys()));
+		VariableNameGenerator nameGenerator = new VariableNameGenerator(allNames.union(throughNames.keys()));
 		for (Pair<String, ImmutableSet<String>> pair : throughNames) {
-			Maybe<ImmutableSet<String>> otherModules = names.get(pair.left);
+			Maybe<ImmutableSet<String>> otherModules = globalNames.get(pair.left);
 			if (otherModules.isNothing()) {
 				continue;
 			}
-			names = names.put(pair.left, names.get(pair.left).fromJust().union(pair.right));
+			globalNames = globalNames.put(pair.left, globalNames.get(pair.left).fromJust().union(pair.right));
 		}
 		HashTable<String, HashTable<String, String>> renamingMaps = modules.foldLeft((acc, module) -> acc.put(module.left, HashTable.<String, String>emptyUsingEquality().put("*default*", nameGenerator.next())), HashTable.emptyUsingEquality());
-		for (Pair<String, ImmutableSet<String>> pair : names) {
+		for (Pair<String, ImmutableSet<String>> pair : globalNames) {
 			ImmutableSet<String> through = throughNames.get(pair.left).orJust(ImmutableSet.emptyUsingEquality());
 			if (pair.right.length() > 1) {
 				renamingMaps = pair.right.foldAbelian((str, acc) -> through.contains(str) ? acc : acc.put(str, acc.get(str).fromJust().put(pair.left, nameGenerator.next())), renamingMaps);

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableReferenceExtractor.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/VariableReferenceExtractor.java
@@ -1,0 +1,22 @@
+package com.shapesecurity.bandolier.es2017.transformations;
+
+import com.shapesecurity.functional.data.ImmutableList;
+import com.shapesecurity.functional.data.ImmutableSet;
+import com.shapesecurity.shift.es2017.scope.Scope;
+import com.shapesecurity.shift.es2017.scope.Variable;
+
+import javax.annotation.Nonnull;
+
+// determines all referenced variable names for a module,
+public class VariableReferenceExtractor {
+
+	private VariableReferenceExtractor() {
+
+	}
+
+	public static ImmutableSet<String> extractAllReferencedVariableNames(@Nonnull Scope globalScope) {
+		return ImmutableList.from(globalScope.variables().toArray(new Variable[0])).map(variable -> variable.name).uniqByEquality()
+			.union(globalScope.children.flatMap(scope -> extractAllReferencedVariableNames(scope).toList()).uniqByEquality());
+	}
+
+}

--- a/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
@@ -114,6 +114,7 @@ public class BundlerTest extends TestCase {
 		modules.put("/root/renaming_dep.js", "export var x = 5; export function setX(y) { x = y; }");
 		modules.put("/root/normalizing/js1.js", "import './js2.js'; import '../normalizing/js2.js';");
 		modules.put("/root/normalizing/js2.js", "");
+		modules.put("/root/test_name_collision.js", "import * as x from '/root/test_name_collision.js'; export var result = (function(){var e = 5; e = 10; return e;})()");
 		loader = new TestLoader(modules);
 	}
 
@@ -252,7 +253,7 @@ public class BundlerTest extends TestCase {
 
 	@Test
 	public void testBundle() throws Exception {
-		//testResult("/root/lib1/js0.js", null, resolver, loader); // the bundler is innocent!
+		testResult("/root/lib1/js0.js", null, resolver, loader); // the bundler is innocent!
 		testResult("/root/lib1/js1.js", 142.0, resolver, loader); // simple import
 		testResult("/root/lib1/js3.js", 142.0, resolver, loader); // simple import / current dir
 		testResult("/root/lib1/js4.js", 142.0, resolver, loader); // simple import / parent dir
@@ -277,6 +278,7 @@ public class BundlerTest extends TestCase {
 		testResult("/root/loadJson.esm", 1.0, resolver, loader);
 
 		testResult("/root/thisIsUndefined.js", null, resolver, loader);
+		testResult("/root/test_name_collision.js", 10.0, resolver, loader);
 		testResultPierced("/root/circular1.js", 12.0, resolver, loader);
 		testResultPierced("/root/circular2.js", Double.NaN, resolver, loader);
 		testResultPierced("/root/renaming.js", 15.0, resolver, loader);


### PR DESCRIPTION
The import assignment resolver fails to see generated module names as different from function locals of the same name. To avoid excessive scope analysis throughout execution, all possible name collisions are handled in the variable name generator to avoid this. Fixes #59.