### PR TITLE
do not wrap default-exported functions in object literals

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {
@@ -19,5 +19,8 @@
     "url": "https://github.com/shapesecurity/bandolier/issues"
   },
   "homepage": "https://github.com/shapesecurity/bandolier#readme",
-  "files": ["index.js", "bin"]
+  "files": [
+    "index.js",
+    "bin"
+  ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.2.3</version>
+    <version>3.2.4</version>
     <packaging>jar</packaging>
 
 

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -779,20 +779,14 @@ public class ImportExportConnector {
 						names = names.cons("default");
 						if (body instanceof FunctionDeclaration) {
 							FunctionDeclaration declaration = (FunctionDeclaration) body;
-							String name = declaration.name.name;
-							if (invertedOriginalRenamingMaps.get(module).fromJust().get(name).orJust("").equals("*default*")) {
-								name = "default";
-							}
-							Expression expressionBody = new StaticMemberExpression(new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName(name), new FunctionExpression(declaration.isAsync, declaration.isGenerator, Maybe.empty(), declaration.params, declaration.body)))), name);
-							statements = statements.append(ImmutableList.of(new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Var, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
-							continue;
+							Expression expressionBody = new FunctionExpression(declaration.isAsync, declaration.isGenerator, Maybe.empty(), declaration.params, declaration.body);
+							toAppend = toAppend.cons((new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Var, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
 						} else if (body instanceof ClassDeclaration) {
-							toAppend = toAppend.cons(((Statement) body));
+							ClassDeclaration declaration = (ClassDeclaration) body;
+							Expression expressionBody = new ClassExpression(Maybe.empty(), declaration._super, declaration.elements);
+							toAppend = toAppend.cons((new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Const, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
 						} else {
 							Expression expressionBody = (Expression) body;
-							if (body instanceof FunctionExpression) {
-								expressionBody = new StaticMemberExpression(new ObjectExpression(ImmutableList.of(new DataProperty(new StaticPropertyName("default"), expressionBody))), "default");
-							}
 							toAppend = toAppend.cons((new VariableDeclarationStatement(new VariableDeclaration(VariableDeclarationKind.Var, ImmutableList.of(new VariableDeclarator(new BindingIdentifier(exportExpressionNames.get(exportDefault)), Maybe.of(expressionBody)))))));
 						}
 					} else if (item instanceof ExportLocals) {

--- a/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
@@ -155,6 +155,37 @@ public class BundlerTest extends TestCase {
 		assertEquals(deps, expected);
 	}
 
+	public void testExportDefault() throws Exception {
+		Map<String, String> modules = new HashMap<>();
+		modules.put("/import.js", "import f from './export.js'; export var result = (new f).x;");
+		TestLoader localLoader = new TestLoader(modules);
+
+		modules.put("/export.js", "export default function(){ return { x: 42 }; }");
+		testResult("/import.js", 42.0, resolver, localLoader);
+
+		modules.put("/export.js", "export default (function(){ return { x: 42 }; });");
+		testResult("/import.js", 42.0, resolver, localLoader);
+
+		modules.put("/export.js", "export default function SOMETHING (){ return { x: 42 }; }");
+		testResult("/import.js", 42.0, resolver, localLoader);
+
+		modules.put("/export.js", "export default (function SOMETHING (){ return { x: 42 }; });");
+		testResult("/import.js", 42.0, resolver, localLoader);
+
+		// disabled because nashorn lacks support for `class`
+		// modules.put("/export.js", "export default class { constructor(){ return { x: 42 }; } }");
+		// testResult("/import.js", 42.0, resolver, localLoader);
+
+		// modules.put("/export.js", "export default (class { constructor(){ return { x: 42 }; } });");
+		// testResult("/import.js", 42.0, resolver, localLoader);
+
+		// modules.put("/export.js", "export default class SOMETHING { constructor(){ return { x: 42 }; } }");
+		// testResult("/import.js", 42.0, resolver, localLoader);
+
+		// modules.put("/export.js", "export default (class SOMETHING { constructor(){ return { x: 42 }; } });");
+		// testResult("/import.js", 42.0, resolver, localLoader);
+	}
+
 	public void testDeterminism() throws Exception {
 		Map<String, String> modules = new HashMap<>();
 		modules.put("/js1.js", "import {b} from './js2.js'; import {c} from './js3.js'; export var result = 'a' + b + c");

--- a/src/test/java/com/shapesecurity/bandolier/es2017/Test262.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/Test262.java
@@ -143,7 +143,7 @@ public class Test262 {
 			"namespace/internals/own-property-keys-sort.js",
 			"namespace/internals/delete-exported-init.js",
 
-			// Nashorn bug in object expressions not setting function expression names.
+			// Nashorn does not perform function name inference
 			"eval-export-dflt-expr-fn-anon.js",
 			"instn-named-bndng-dflt-fun-named.js",
 			"instn-named-bndng-dflt-fun-anon.js",


### PR DESCRIPTION
On master, `export default (function f (){});` compiles to

```js
(function(e) {
  'use strict';
  var w = { default: function f() {} }.default;
  var r = { __proto__: null, default: w };
  if (e.Symbol)
    e.Object.defineProperty(r, e.Symbol.toStringTag, { value: 'Module' });
  r = e.Object.freeze(r);
  return r;
})(this);

```

Now it compiles to

```js
(function(e) {
  'use strict';
  var w = function f() {};
  var r = { __proto__: null, default: w };
  if (e.Symbol)
    e.Object.defineProperty(r, e.Symbol.toStringTag, { value: 'Module' });
  r = e.Object.freeze(r);
  return r;
})(this);
```

There's also a test that default exports work, because I'm not sure they were sufficiently stressed before.

Contains version bump commit, so please **rebase**, not squash.