### PR TITLE
Determinism without sorting variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.3.1</version>
+    <version>3.3.2</version>
     <packaging>jar</packaging>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.shapesecurity.shift</groupId>
             <artifactId>es2017</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.1</version>
         </dependency>
         <dependency>
             <groupId>com.shapesecurity</groupId>

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -320,8 +320,7 @@ public class ImportExportConnector {
 		HashTable<Module, HashTable<String, Variable>> invertedOriginalRenamingMaps = originalRenamingMap.map(map -> map.foldLeft((acc, pair) -> acc.put(pair.right, pair.left), HashTable.emptyUsingEquality()));
 
 		// variables that represent default exports, but not considered by scope analysis
-		// variables are created indexed negative to the sorted order to not conflict with scope analysis indices
-		HashTable<Module, Variable> moduleDefaults = sortedModules.foldLeft((acc, module) -> acc.put(module, new Variable(nameGenerator.next(), ImmutableList.empty(), ImmutableList.empty(), -acc.length - 1)), HashTable.emptyUsingIdentity());
+		HashTable<Module, Variable> moduleDefaults = sortedModules.foldLeft((acc, module) -> acc.put(module, new Variable(nameGenerator.next(), ImmutableList.empty(), ImmutableList.empty())), HashTable.emptyUsingIdentity());
 
 		// perform initial export extraction and prepare for proxy export resolution
 		for (Module module : modules) {
@@ -426,7 +425,6 @@ public class ImportExportConnector {
 		}
 
 		// build dependency graph
-		HashMap<Module, HashSet<Module>> dependedBy = new HashMap<>();
 		HashMap<Module, LinkedList<Module>> dependingOn = new HashMap<>();
 		for (Module module : modules) {
 			LinkedList<Module> dependents = null;
@@ -444,7 +442,6 @@ public class ImportExportConnector {
 						moduleSpecifier = ((ExportAllFrom) item).moduleSpecifier;
 					}
 					Module from = specifierToModule.get(moduleSpecifier).fromJust();
-					dependedBy.computeIfAbsent(from, mod -> new HashSet<>()).add(module);
 					dependents.add(from);
 				}
 			}


### PR DESCRIPTION
See https://github.com/shapesecurity/shift-java/pull/245. Won't build until that's released.

Instead of sorting all variables within a module, or even across modules, this instead sorts variables within a scope according to their name (which is deterministic) and relies on the list of scopes being deterministic and the list of modules being sorted.