### PR TITLE
Allow not freezing/tagging/setting proto of namespace objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bandolier",
-  "version": "3.3.2",
+  "version": "3.4.0",
   "description": "Bundles es2015 modules",
   "main": "index.js",
   "scripts": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.3.2</version>
+    <version>3.4.0</version>
     <packaging>jar</packaging>
 
 

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
@@ -13,7 +13,8 @@ public final class BundlerOptions {
 
 	public enum ExportStrategy {
 		EXPLICIT,
-		ALL_GLOBALS
+		ALL_GLOBALS,
+		NONE,
 	}
 
 	public enum DangerLevel {
@@ -61,6 +62,10 @@ public final class BundlerOptions {
 	}
 
 	public BundlerOptions withRealNamespaceObjects(boolean realNamespaceObjects) {
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
+	}
+
+	public BundlerOptions withExportStrategy(ExportStrategy exportStrategy) {
 		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
 	}
 }

--- a/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/bundlers/BundlerOptions.java
@@ -30,32 +30,37 @@ public final class BundlerOptions {
 	public final DangerLevel dangerLevel;
 	public final boolean throwOnCircularDependency;
 	public final boolean throwOnImportAssignment;
+	public final boolean realNamespaceObjects;
 
 
-	public BundlerOptions(@Nonnull ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy, @Nonnull ExportStrategy exportStrategy, @Nonnull DangerLevel dangerLevel, boolean throwOnCircularDependency, boolean throwOnImportAssignment) {
+	public BundlerOptions(@Nonnull ImportUnresolvedResolutionStrategy importUnresolvedResolutionStrategy, @Nonnull ExportStrategy exportStrategy, @Nonnull DangerLevel dangerLevel, boolean throwOnCircularDependency, boolean throwOnImportAssignment, boolean realNamespaceObjects) {
 		this.importUnresolvedResolutionStrategy = importUnresolvedResolutionStrategy;
 		this.exportStrategy = exportStrategy;
 		this.dangerLevel = dangerLevel;
 		this.throwOnCircularDependency = throwOnCircularDependency;
 		this.throwOnImportAssignment = throwOnImportAssignment;
+		this.realNamespaceObjects = realNamespaceObjects;
 	}
 
-	public static final BundlerOptions NODE_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.DEFAULT_TO_UNDEFINED, ExportStrategy.ALL_GLOBALS, DangerLevel.SAFE, false, false);
+	public static final BundlerOptions NODE_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.DEFAULT_TO_UNDEFINED, ExportStrategy.ALL_GLOBALS, DangerLevel.SAFE, false, false, true);
 
-	public static final BundlerOptions SPEC_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, false, false);
+	public static final BundlerOptions SPEC_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, false, false, true);
 
-	public static final BundlerOptions DEFAULT_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, true, true);
+	public static final BundlerOptions DEFAULT_OPTIONS = new BundlerOptions(ImportUnresolvedResolutionStrategy.COMPILE_ERROR, ExportStrategy.EXPLICIT, DangerLevel.SAFE, true, true, true);
 
 	public BundlerOptions withDangerLevel(@Nonnull DangerLevel dangerLevel) {
-		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
 	}
 
 	public BundlerOptions withThrowOnCircularDependency(boolean throwOnCircularDependency) {
-		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
 	}
 
 	public BundlerOptions withThrowOnImportAssignment(boolean throwOnImportAssignment) {
-		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment);
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
 	}
 
+	public BundlerOptions withRealNamespaceObjects(boolean realNamespaceObjects) {
+		return new BundlerOptions(importUnresolvedResolutionStrategy, exportStrategy, dangerLevel, throwOnCircularDependency, throwOnImportAssignment, realNamespaceObjects);
+	}
 }

--- a/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
+++ b/src/main/java/com/shapesecurity/bandolier/es2017/transformations/ImportExportConnector.java
@@ -484,7 +484,9 @@ public class ImportExportConnector {
 		HashSet<VariableReference> unresolvedImportReferences = new HashSet<>();
 
 		HashSet<Module> usedExportModules = new HashSet<>();
-		usedExportModules.add(entrypoint);
+		if (options.exportStrategy != BundlerOptions.ExportStrategy.NONE) {
+			usedExportModules.add(entrypoint);
+		}
 
 		HashSet<Module> nonSelfDependentModules = new HashSet<>();
 
@@ -797,9 +799,12 @@ public class ImportExportConnector {
 			statements = finalAppend.foldLeft(ImmutableList::cons, statements);
 		}
 
-		Script script = new Script(ImmutableList.of(new Directive("use strict")), statements.cons(
-				new ReturnStatement(Maybe.of(new IdentifierExpression(moduleExportReference.get(entrypoint).fromJust())))
-		).reverse());
+		if (options.exportStrategy != BundlerOptions.ExportStrategy.NONE) {
+			statements = statements.cons(
+					new ReturnStatement(Maybe.of(new IdentifierExpression(moduleExportReference.get(entrypoint).fromJust())))
+			);
+		}
+		Script script = new Script(ImmutableList.of(new Directive("use strict")), statements.reverse());
 
 		return Pair.of(script, globalBinding);
 	}

--- a/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
+++ b/src/test/java/com/shapesecurity/bandolier/es2017/BundlerTest.java
@@ -394,4 +394,18 @@ public class BundlerTest extends TestCase {
 				"return _t;\n" +
 				"}(this));\n", bundledWithoutRealNamespace);
 	}
+
+	public void testNoExports() throws Exception {
+		Path path = Paths.get("/root/lib1/js1.js");
+		String source = loader.loadResource(path);
+		BundlerOptions options = BundlerOptions.DEFAULT_OPTIONS.withExportStrategy(BundlerOptions.ExportStrategy.NONE);
+
+		String bundledWithoutExports = TestUtils.toString(Bundler.bundleModule(options, Parser.parseModule(source), path, resolver, loader, new PiercedModuleBundler()));
+		assertEquals("(function(_e){\n" +
+				"\"use strict\";\n" +
+				"var b=100;\n" +
+				"var result=42+b;\n" +
+				"}(this));\n", bundledWithoutExports);
+	}
+
 }


### PR DESCRIPTION
By default Bandolier freezes `toStringTag`s, and sets the `__proto__` of namespace objects, which is necessary to match actual semantics. But in a lot of cases you know your code isn't going to rely on any of that, in which case this is just noise. So add an option to disable that.

Also add an option to skip exports from the entrypoint entirely, for when you just want side effects.

This PR includes a version bump commit, so please **rebase**, not squash.