### PR TITLE
Version 4.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.shapesecurity.bandolier</groupId>
     <artifactId>es2017</artifactId>
-    <version>3.5.1</version>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
 
 


### PR DESCRIPTION
Calling this major due to dropping support for java 8 (in https://github.com/shapesecurity/bandolier/pull/89). It might still work with 8, but we're not officially going to support it.
